### PR TITLE
Implement simple bot behaviour

### DIFF
--- a/src/io/xeros/content/commands/owner/Bots.java
+++ b/src/io/xeros/content/commands/owner/Bots.java
@@ -8,6 +8,7 @@ import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.model.entity.player.Position;
 import io.xeros.model.entity.player.Right;
+import io.xeros.model.entity.player.bot.BotBehaviour;
 import io.xeros.util.Captcha;
 import io.xeros.util.Misc;
 import org.jetbrains.annotations.NotNull;
@@ -38,6 +39,12 @@ public class Bots extends Command {
                     Player.createBot("Bot " + botCounter++, Right.PLAYER, new Position(x, y));
                 }
                 break;
+            case "spawnfighter":
+                spawnBots(player, Integer.parseInt(args[1]), BotBehaviour.Type.FIGHT_NEAREST_NPC);
+                break;
+            case "spawnwoodcutter":
+                spawnBots(player, Integer.parseInt(args[1]), BotBehaviour.Type.CHOP_NEAREST_TREE);
+                break;
             case "talk":
                 CycleEventHandler.getSingleton().addEvent(player, new CycleEvent() {
                     @Override
@@ -48,6 +55,16 @@ public class Bots extends Command {
                 break;
             default:
                 player.sendMessage("No actionable command with '{}'", args[0]);
+        }
+    }
+
+    private void spawnBots(Player player, int amount, BotBehaviour.Type type) {
+        player.sendMessage("Spawning " + amount + " bots.");
+        for (int i = 0; i < amount; i++) {
+            int x = player.getX() + Misc.random(-2, 2);
+            int y = player.getY() + Misc.random(-2, 2);
+            Player bot = Player.createBot("Bot " + botCounter++, Right.PLAYER, new Position(x, y));
+            bot.addQueuedAction(plr -> plr.addTickable(new BotBehaviour(type)));
         }
     }
 

--- a/src/io/xeros/model/entity/player/bot/BotBehaviour.java
+++ b/src/io/xeros/model/entity/player/bot/BotBehaviour.java
@@ -1,0 +1,92 @@
+package io.xeros.model.entity.player.bot;
+
+import io.xeros.Server;
+import io.xeros.content.skills.woodcutting.Tree;
+import io.xeros.content.skills.woodcutting.Woodcutting;
+import io.xeros.model.collisionmap.WorldObject;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.npc.NPCHandler;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+import io.xeros.model.tickable.Tickable;
+import io.xeros.model.tickable.TickableContainer;
+import io.xeros.model.world.objects.GlobalObject;
+
+import java.util.Optional;
+
+/**
+ * Simple behaviour controller for bot players.
+ */
+public class BotBehaviour implements Tickable<Player> {
+
+    public enum Type {
+        FIGHT_NEAREST_NPC,
+        CHOP_NEAREST_TREE
+    }
+
+    private final Type type;
+
+    public BotBehaviour(Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public void tick(TickableContainer<Player> container, Player bot) {
+        if (bot == null || bot.disconnected || !bot.isBot()) {
+            container.stop();
+            return;
+        }
+
+        switch (type) {
+            case FIGHT_NEAREST_NPC:
+                fightNearestNpc(bot);
+                break;
+            case CHOP_NEAREST_TREE:
+                chopNearestTree(bot);
+                break;
+        }
+    }
+
+    private void fightNearestNpc(Player bot) {
+        NPC nearest = null;
+        double best = Double.MAX_VALUE;
+        for (NPC npc : NPCHandler.npcs) {
+            if (npc == null || npc.isDeadOrDying() || npc.heightLevel != bot.getHeight())
+                continue;
+            double distance = bot.getPosition().distanceTo(npc.getPosition());
+            if (distance < best) {
+                best = distance;
+                nearest = npc;
+            }
+        }
+        if (nearest != null && best <= 10) {
+            bot.attackEntity(nearest);
+        }
+    }
+
+    private void chopNearestTree(Player bot) {
+        WorldObject tree = findNearbyTree(bot, 4);
+        if (tree != null) {
+            Woodcutting.getInstance().chop(bot, tree.getId(), tree.getX(), tree.getY());
+        }
+    }
+
+    private WorldObject findNearbyTree(Player bot, int radius) {
+        Position pos = bot.getPosition();
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dy = -radius; dy <= radius; dy++) {
+                int x = pos.getX() + dx;
+                int y = pos.getY() + dy;
+                for (Tree tree : Tree.values()) {
+                    for (int id : tree.getTreeIds()) {
+                        Optional<WorldObject> obj = bot.getRegionProvider().get(x, y).getWorldObject(id, x, y, pos.getHeight());
+                        if (obj.isPresent() && !Server.getGlobalObjects().exists(tree.getStumpId(), x, y)) {
+                            return obj.get();
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add `BotBehaviour` to automate bots
- extend `::bots` command to spawn fighters or woodcutters

## Testing
- `gradle test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68826da56ba883208483498162a2f8a8