### PR TITLE
Improve bot behaviour

### DIFF
--- a/src/io/xeros/content/commands/owner/Bots.java
+++ b/src/io/xeros/content/commands/owner/Bots.java
@@ -8,10 +8,13 @@ import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.model.entity.player.Position;
 import io.xeros.model.entity.player.Right;
+import io.xeros.model.entity.player.bot.BotBehaviour;
+import io.xeros.model.EquipmentSetup;
 import io.xeros.util.Captcha;
 import io.xeros.util.Misc;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -19,6 +22,20 @@ import java.util.stream.Collectors;
 public class Bots extends Command {
 
     private static int botCounter = 0;
+
+    private static final String[] PREFIXES = {
+        "Iron", "Rune", "Dark", "Sir", "Lady", "Lord", "Swift", "Mystic"
+    };
+    private static final String[] SUFFIXES = {
+        "Knight", "Mage", "Scaper", "Hunter", "Ranger", "Warrior", "Slayer", "Druid"
+    };
+
+    private static String randomBotName() {
+        String prefix = PREFIXES[Misc.random(PREFIXES.length - 1)];
+        String suffix = SUFFIXES[Misc.random(SUFFIXES.length - 1)];
+        int num = Misc.random(99);
+        return prefix + suffix + String.format("%02d", num);
+    }
 
     @Override
     public void execute(Player player, String commandName, String input) {
@@ -30,13 +47,13 @@ public class Bots extends Command {
         String[] args = input.split(" ");
         switch (args[0]) {
             case "spawn":
-                int amount = Integer.parseInt(args[1]);
-                player.sendMessage("Adding " + amount + " bots.");
-                for (int i = 0; i < amount; i++) {
-                    int x = 3085 + Misc.random(0, 25);
-                    int y = 3530 + Misc.random(0, 25);
-                    Player.createBot("Bot " + botCounter++, Right.PLAYER, new Position(x, y));
-                }
+                spawnBots(player, Integer.parseInt(args[1]), null);
+                break;
+            case "spawnfighter":
+                spawnBots(player, Integer.parseInt(args[1]), BotBehaviour.Type.FIGHT_NEAREST_NPC);
+                break;
+            case "spawnwoodcutter":
+                spawnBots(player, Integer.parseInt(args[1]), BotBehaviour.Type.CHOP_NEAREST_TREE);
                 break;
             case "talk":
                 CycleEventHandler.getSingleton().addEvent(player, new CycleEvent() {
@@ -48,6 +65,45 @@ public class Bots extends Command {
                 break;
             default:
                 player.sendMessage("No actionable command with '{}'", args[0]);
+        }
+    }
+
+    private void spawnBots(Player player, int amount, BotBehaviour.Type type) {
+        player.sendMessage("Spawning " + amount + " bots.");
+        for (int i = 0; i < amount; i++) {
+            int x = player.getX() + Misc.random(-2, 2);
+            int y = player.getY() + Misc.random(-2, 2);
+            Player bot = Player.createBot(randomBotName(), Right.PLAYER, new Position(x, y));
+            bot.addQueuedLoginAction(Bots::randomizeStats);
+            bot.addQueuedLoginAction(Bots::equipRandomSetup);
+            if (type != null) {
+                bot.addQueuedLoginAction(plr -> plr.addTickable(new BotBehaviour(type)));
+            }
+        }
+    }
+
+    private static void randomizeStats(Player bot) {
+        for (int i = 0; i < bot.playerLevel.length; i++) {
+            int level = Misc.random(1, 99);
+            bot.playerLevel[i] = level;
+            bot.playerXP[i] = bot.getPA().getXPForLevel(level) + 1;
+            bot.getPA().setSkillLevel(i, bot.playerLevel[i], bot.playerXP[i]);
+        }
+        bot.getPA().refreshSkills();
+    }
+
+    private static void equipRandomSetup(Player bot) {
+        List<String> setups = EquipmentSetup.listSetups().stream()
+                .map(s -> s.split(" \\(")[0])
+                .collect(Collectors.toList());
+        if (setups.isEmpty()) {
+            return;
+        }
+        String setup = setups.get(Misc.random(setups.size() - 1));
+        try {
+            EquipmentSetup.equip(bot, setup);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 

--- a/src/io/xeros/model/entity/player/Player.java
+++ b/src/io/xeros/model/entity/player/Player.java
@@ -1281,6 +1281,7 @@ public class Player extends Entity {
         player.playerPass = "ArkCaneDoesntHaveBotsExiled";
         player.setIpAddress("");
         player.addQueuedAction(plr -> plr.moveTo(position));
+        player.addQueuedLoginAction(plr -> Server.clanManager.getHelpClan().addMember(plr));
 
         Server.getIoExecutorService().submit(() -> {
             try {

--- a/src/io/xeros/model/entity/player/bot/BotBehaviour.java
+++ b/src/io/xeros/model/entity/player/bot/BotBehaviour.java
@@ -1,0 +1,122 @@
+package io.xeros.model.entity.player.bot;
+
+import io.xeros.Server;
+import io.xeros.content.skills.woodcutting.Tree;
+import io.xeros.content.skills.woodcutting.Woodcutting;
+import io.xeros.model.collisionmap.WorldObject;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.npc.NPCHandler;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+import io.xeros.model.tickable.Tickable;
+import io.xeros.model.tickable.TickableContainer;
+import io.xeros.util.Misc;
+import io.xeros.model.world.objects.GlobalObject;
+
+import java.util.Optional;
+
+/**
+ * Simple behaviour controller for bot players.
+ */
+public class BotBehaviour implements Tickable<Player> {
+
+    public enum Type {
+        FIGHT_NEAREST_NPC,
+        CHOP_NEAREST_TREE
+    }
+
+    private final Type type;
+    private int nextActionTick = 0;
+
+    public BotBehaviour(Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public void tick(TickableContainer<Player> container, Player bot) {
+        if (bot == null || bot.disconnected || !bot.isBot()) {
+            container.stop();
+            return;
+        }
+
+        if (container.getTicks() < nextActionTick) {
+            return;
+        }
+        nextActionTick = container.getTicks() + Misc.random(3, 7);
+
+        switch (type) {
+            case FIGHT_NEAREST_NPC:
+                fightNearestNpc(bot);
+                break;
+            case CHOP_NEAREST_TREE:
+                chopNearestTree(bot);
+                break;
+        }
+    }
+
+    private void fightNearestNpc(Player bot) {
+        NPC nearest = null;
+        double best = Double.MAX_VALUE;
+        for (NPC npc : NPCHandler.npcs) {
+            if (npc == null || npc.isDeadOrDying() || npc.heightLevel != bot.getHeight())
+                continue;
+            double distance = bot.getPosition().distanceTo(npc.getPosition());
+            if (distance < best) {
+                best = distance;
+                nearest = npc;
+            }
+        }
+
+        if (nearest == null || best > 10) {
+            randomWalk(bot);
+            return;
+        }
+
+        if (best > 1) {
+            bot.getPA().playerWalk(nearest.getX(), nearest.getY());
+        } else if (bot.npcAttackingIndex == 0) {
+            bot.attackEntity(nearest);
+        }
+    }
+
+    private void chopNearestTree(Player bot) {
+        WorldObject tree = findNearbyTree(bot, 6);
+        if (tree == null) {
+            randomWalk(bot);
+            return;
+        }
+
+        if (bot.distanceToPoint(tree.getX(), tree.getY()) > 1) {
+            bot.getPA().playerWalk(tree.getX(), tree.getY());
+        } else {
+            Woodcutting.getInstance().chop(bot, tree.getId(), tree.getX(), tree.getY());
+        }
+    }
+
+    private WorldObject findNearbyTree(Player bot, int radius) {
+        Position pos = bot.getPosition();
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dy = -radius; dy <= radius; dy++) {
+                int x = pos.getX() + dx;
+                int y = pos.getY() + dy;
+                for (Tree tree : Tree.values()) {
+                    for (int id : tree.getTreeIds()) {
+                        Optional<WorldObject> obj = bot.getRegionProvider().get(x, y).getWorldObject(id, x, y, pos.getHeight());
+                        if (obj.isPresent() && !Server.getGlobalObjects().exists(tree.getStumpId(), x, y)) {
+                            return obj.get();
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void randomWalk(Player bot) {
+        int dx = Misc.random(-1, 1);
+        int dy = Misc.random(-1, 1);
+        if (dx != 0 || dy != 0) {
+            bot.getPA().playerWalk(bot.getX() + dx, bot.getY() + dy);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- randomize bot name generation with RuneScape-style prefixes and suffixes
- add delays and wandering to bot behaviour
- make fighter bots path to NPCs before attacking
- make woodcutter bots walk to trees before chopping
- bots now log into the "help" clan chat
- spawn commands give bots random stats and a random equipment preset

## Testing
- `sh gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68826da56ba883208483498162a2f8a8