### PR TITLE
Add boss instance unlock NPC

### DIFF
--- a/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
@@ -1,0 +1,59 @@
+package io.xeros.content.dialogue.impl;
+
+import io.xeros.content.dialogue.DialogueBuilder;
+import io.xeros.content.dialogue.DialogueOption;
+import io.xeros.content.instances.BossInstance;
+import io.xeros.model.entity.player.Player;
+import io.xeros.util.Misc;
+
+public class BossInstanceDialogue extends DialogueBuilder {
+
+    private static final int NPC_ID = io.xeros.model.Npcs.INSTANCE_MASTER;
+
+    public BossInstanceDialogue(Player player) {
+        super(player);
+        setNpcId(NPC_ID);
+        mainMenu();
+    }
+
+    private void mainMenu() {
+        option(new DialogueOption("OSRS Boss Instances", p -> osrsMenu()),
+                new DialogueOption("Custom Boss Instances", p -> customMenu()),
+                DialogueOption.nevermind());
+    }
+
+    private void osrsMenu() {
+        option(optionFor(BossInstance.ZULRAH),
+                optionFor(BossInstance.KRAKEN),
+                optionFor(BossInstance.CERBERUS),
+                optionFor(BossInstance.VORKATH),
+                optionFor(BossInstance.HYDRA));
+    }
+
+    private void customMenu() {
+        option(optionFor(BossInstance.GROTESQUE_GUARDIANS),
+                optionFor(BossInstance.OBOR),
+                optionFor(BossInstance.BRYOPHYTA),
+                optionFor(BossInstance.DUKE_SUCELLUS),
+                optionFor(BossInstance.NIGHTMARE));
+    }
+
+    private DialogueOption optionFor(BossInstance instance) {
+        return new DialogueOption(instance.getName(), p -> handle(instance));
+    }
+
+    private void handle(BossInstance instance) {
+        if (!getPlayer().getUnlockedInstances().contains(instance)) {
+            if (getPlayer().foundryPoints < instance.getCost()) {
+                getPlayer().sendMessage("You need " + Misc.formatCoins(instance.getCost()) + " upgrade points to unlock this instance.");
+                getPlayer().getPA().closeAllWindows();
+                return;
+            }
+            getPlayer().foundryPoints -= instance.getCost();
+            getPlayer().getUnlockedInstances().add(instance);
+            getPlayer().sendMessage("You unlock the " + instance.getName() + " instance!");
+        }
+        instance.start(getPlayer());
+        getPlayer().getPA().closeAllWindows();
+    }
+}

--- a/src/io/xeros/content/instances/BossInstance.java
+++ b/src/io/xeros/content/instances/BossInstance.java
@@ -1,0 +1,55 @@
+package io.xeros.content.instances;
+
+import io.xeros.content.bosses.Cerberus;
+import io.xeros.content.bosses.Kraken;
+import io.xeros.content.bosses.Vorkath;
+import io.xeros.content.bosses.bryophyta.Bryophyta;
+import io.xeros.content.bosses.dukesucellus.DukeSucellus;
+import io.xeros.content.bosses.grotesqueguardians.GrotesqueInstance;
+import io.xeros.content.bosses.hydra.AlchemicalHydra;
+import io.xeros.content.bosses.nightmare.NightmareInstance;
+import io.xeros.content.bosses.obor.OborInstance;
+import io.xeros.content.bosses.zulrah.Zulrah;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Player;
+
+import java.util.function.Consumer;
+
+/**
+ * Represents a boss instance that can be unlocked and started.
+ */
+public enum BossInstance {
+    ZULRAH("Zulrah", 5_000_000, p -> new Zulrah(p).initialize()),
+    KRAKEN("Kraken", 2_000_000, Kraken::init),
+    CERBERUS("Cerberus", 3_000_000, Cerberus::init),
+    VORKATH("Vorkath", 4_000_000, p -> Vorkath.enterInstance(p, p.getIndex() * 4)),
+    HYDRA("Alchemical Hydra", 6_000_000, p -> new AlchemicalHydra(p)),
+    GROTESQUE_GUARDIANS("Grotesque Guardians", 4_000_000, p -> { GrotesqueInstance i = new GrotesqueInstance(); i.enter(p); }),
+    OBOR("Obor", 1_000_000, p -> new OborInstance().begin(p)),
+    BRYOPHYTA("Bryophyta", 1_000_000, p -> new Bryophyta().enter(p)),
+    DUKE_SUCELLUS("Duke Sucellus", 8_000_000, p -> { DukeSucellus inst = new DukeSucellus(p, Boundary.DUKE_INSTANCE); DukeSucellus.enter(p, inst); }),
+    NIGHTMARE("Nightmare", 10_000_000, p -> { NightmareInstance inst = new NightmareInstance(false); inst.add(p); inst.countdown(); });
+
+    private final String name;
+    private final long cost;
+    private final Consumer<Player> starter;
+
+    BossInstance(String name, long cost, Consumer<Player> starter) {
+        this.name = name;
+        this.cost = cost;
+        this.starter = starter;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public long getCost() {
+        return cost;
+    }
+
+    public void start(Player player) {
+        starter.accept(player);
+    }
+}
+

--- a/src/io/xeros/model/Npcs.java
+++ b/src/io/xeros/model/Npcs.java
@@ -9559,5 +9559,6 @@ public class Npcs {
     public static final int ABYSSAL_WALKER_3 = 11_454;
     public static final int THE_GREAT_GUARDIAN_2 = 11_455;
     public static final int THE_GREAT_GUARDIAN_3 = 11_456;
+    public static final int INSTANCE_MASTER = 9_010;
 
 }

--- a/src/io/xeros/model/entity/player/Player.java
+++ b/src/io/xeros/model/entity/player/Player.java
@@ -826,6 +826,10 @@ public class Player extends Entity {
     public int xpMaxSkills;
     public int exchangePoints;
     public long foundryPoints;
+    /**
+     * Boss instances the player has unlocked.
+     */
+    private java.util.EnumSet<io.xeros.content.instances.BossInstance> unlockedInstances = java.util.EnumSet.noneOf(io.xeros.content.instances.BossInstance.class);
     public int totalEarnedExchangePoints;
     public int referallFlag;
     public int amDonated;
@@ -6202,6 +6206,13 @@ public class Player extends Entity {
     public Player MiniMeOwner = null;
 
     public BlastFurnace blastFurnace = new BlastFurnace();
+
+    /**
+     * Get the set of unlocked boss instances.
+     */
+    public java.util.EnumSet<io.xeros.content.instances.BossInstance> getUnlockedInstances() {
+        return unlockedInstances;
+    }
 
     public BlastFurnace getBlastFurnace() {
         return blastFurnace;

--- a/src/io/xeros/model/entity/player/packets/npcoptions/NpcOptionOne.java
+++ b/src/io/xeros/model/entity/player/packets/npcoptions/NpcOptionOne.java
@@ -953,17 +953,20 @@ public class NpcOptionOne {
 			break;
 
 
-		case 7913:
-			if (player.getMode().isIronmanType()
-					|| player.getRights().isOrInherits(Right.GAME_DEVELOPER)) {
-				player.getShops().openShop(41);
-			} else {
-				player.sendMessage("You must be an Iron Man to access this shop.");
-			}
-			break;
-		case 7769:
-			player.getShops().openShop(2);
-			break;
+                case 7913:
+                        if (player.getMode().isIronmanType()
+                                        || player.getRights().isOrInherits(Right.GAME_DEVELOPER)) {
+                                player.getShops().openShop(41);
+                        } else {
+                                player.sendMessage("You must be an Iron Man to access this shop.");
+                        }
+                        break;
+                case Npcs.INSTANCE_MASTER:
+                        player.start(new io.xeros.content.dialogue.impl.BossInstanceDialogue(player));
+                        break;
+                case 7769:
+                        player.getShops().openShop(2);
+                        break;
 
 		
 

--- a/src/io/xeros/model/entity/player/save/PlayerSave.java
+++ b/src/io/xeros/model/entity/player/save/PlayerSave.java
@@ -1104,6 +1104,16 @@ public class PlayerSave {
                                         e.printStackTrace();
                                     }
                                 }
+                            } else if (token.equals("instance-unlocks")) {
+                                for (String s : token3) {
+                                    try {
+                                        io.xeros.content.instances.BossInstance bi = io.xeros.content.instances.BossInstance.valueOf(s);
+                                        p.getUnlockedInstances().add(bi);
+                                    } catch (Exception e) {
+                                        logger.error("Error while loading {}", playerName, e);
+                                        e.printStackTrace();
+                                    }
+                                }
                             } else if (token.startsWith("removedTask")) {
                                 int value = Integer.parseInt(token2);
                                 if (value > -1) {
@@ -1722,6 +1732,17 @@ public class PlayerSave {
                 for (int index = 0; index < unlocks.size(); index++) {
                     characterfile.write(unlocks.get(index).toString());
                     if (index < removed.length - 1) {
+                        characterfile.write("\t");
+                    }
+                }
+            }
+            characterfile.newLine();
+            if (!p.getUnlockedInstances().isEmpty()) {
+                characterfile.write("instance-unlocks = ");
+                int i = 0;
+                for (io.xeros.content.instances.BossInstance bi : p.getUnlockedInstances()) {
+                    characterfile.write(bi.name());
+                    if (i++ < p.getUnlockedInstances().size() - 1) {
                         characterfile.write("\t");
                     }
                 }


### PR DESCRIPTION
## Summary
- add `BossInstance` enum with costs and start functions
- store unlocked boss instances on the player
- save/load instance unlocks with player files
- add dialogue `BossInstanceDialogue` for unlocking and starting bosses
- hook new NPC `INSTANCE_MASTER` into NPC option handling

## Testing
- `gradle test` *(fails: compilation error in BotBehaviour.java)*

------
https://chatgpt.com/codex/tasks/task_e_6889110a7e6083209bc05ec68a053d05