### PR TITLE
Load Discord token from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Based on Xeros.
 ## Setup
 - Enable annotation processing for Lombok.
 - Create a config.yaml in the working directory with the server state: `server_state: DEBUG`.
+- Add your Discord bot token with `discord_bot_token: YOUR_TOKEN`.
 Debug will give you the developer rank on login and fill your bank with various items.
 It will also give you printouts by default.
 

--- a/src/io/xeros/ServerConfiguration.java
+++ b/src/io/xeros/ServerConfiguration.java
@@ -15,6 +15,7 @@ public class ServerConfiguration {
     public static ServerConfiguration getDefault() {
         ServerConfiguration configuration = new ServerConfiguration();
         configuration.serverState = ServerState.PUBLIC;
+        configuration.discordBotToken = "";
         return configuration;
     }
 
@@ -35,6 +36,9 @@ public class ServerConfiguration {
 
     @JsonProperty("hiscores_database")
     private DatabaseCredentials hiscoresDatabase;
+
+    @JsonProperty("discord_bot_token")
+    private String discordBotToken;
 
     @JsonProperty("backup_ftp_credentials")
     private DatabaseCredentials backupFtpCredentials;
@@ -124,5 +128,13 @@ public class ServerConfiguration {
 
     public String getMysqlDumpPath() {
         return mysqlDumpPath;
+    }
+
+    public String getDiscordBotToken() {
+        return discordBotToken;
+    }
+
+    public void setDiscordBotToken(String discordBotToken) {
+        this.discordBotToken = discordBotToken;
     }
 }

--- a/src/io/xeros/util/discord/Discord.java
+++ b/src/io/xeros/util/discord/Discord.java
@@ -36,7 +36,7 @@ public class Discord extends ListenerAdapter {
     public static String ADMIN_ROLE = "891930584446812200";
     public static String GLOBAL_MOD_ROLE = "892423012551389265";
     public static String SUPPORT_ROLE = "892558604580847627";
-    public static final String BOT_TOKEN = "MTA0MDc2MzIwMDUwNjk1NzkwNA.GZtaFT.WSeWJw0IudDLt5ciBEDXd7FBGjt6NLo0zfIROo";
+    public static String BOT_TOKEN = "";
     public static final String DISCORD_THUMBNAIL = "https://turmoilrsps.quest/logo.png";
     public static final String SERVER_LOGO = "https://turmoilrsps.quest/logo.png";
     public static final long GUILD_ID = 605271780302651420L;
@@ -272,6 +272,7 @@ public class Discord extends ListenerAdapter {
     }
 
     public void init() {
+        BOT_TOKEN = Server.getConfiguration().getDiscordBotToken();
         JDABuilder builder = JDABuilder.createDefault(BOT_TOKEN)
                 .enableIntents(GatewayIntent.GUILD_PRESENCES, GatewayIntent.GUILD_MEMBERS)
                 .enableCache(CacheFlag.ACTIVITY)


### PR DESCRIPTION
## Summary
- configure README setup steps for Discord token
- add `discord_bot_token` to `ServerConfiguration`
- pull token from configuration when initializing Discord

## Testing
- `gradle test --no-daemon` *(fails: package io.xeros.content.pet does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6889646e446c8320bbb3c69a817b3b9f