### PR TITLE
Add TOA bosses as instance tokens

### DIFF
--- a/src/io/xeros/content/bosses/toa/SoloAkkha.java
+++ b/src/io/xeros/content/bosses/toa/SoloAkkha.java
@@ -1,0 +1,24 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.minigames.TOA.bosses.Akkha;
+import io.xeros.content.instances.InstancedArea;
+import io.xeros.model.entity.Entity;
+import io.xeros.model.entity.player.Player;
+import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+
+public class SoloAkkha extends Akkha {
+    public SoloAkkha(InstancedArea area) {
+        super(area);
+    }
+
+    @Override
+    public void onDeath() {
+        InstancedArea inst = getInstance();
+        if (inst != null) {
+            for (Player plr : inst.getPlayers()) {
+                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+            }
+            inst.dispose();
+        }
+    }
+}

--- a/src/io/xeros/content/bosses/toa/SoloApmeken.java
+++ b/src/io/xeros/content/bosses/toa/SoloApmeken.java
@@ -1,0 +1,23 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.minigames.TOA.bosses.Apmeken;
+import io.xeros.content.instances.InstancedArea;
+import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.player.Player;
+
+public class SoloApmeken extends Apmeken {
+    public SoloApmeken(InstancedArea area) {
+        super(area);
+    }
+
+    @Override
+    public void onDeath() {
+        InstancedArea inst = getInstance();
+        if (inst != null) {
+            for (Player plr : inst.getPlayers()) {
+                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+            }
+            inst.dispose();
+        }
+    }
+}

--- a/src/io/xeros/content/bosses/toa/SoloBaba.java
+++ b/src/io/xeros/content/bosses/toa/SoloBaba.java
@@ -1,0 +1,23 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.minigames.TOA.bosses.Baba;
+import io.xeros.content.instances.InstancedArea;
+import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.player.Player;
+
+public class SoloBaba extends Baba {
+    public SoloBaba(InstancedArea area) {
+        super(area);
+    }
+
+    @Override
+    public void onDeath() {
+        InstancedArea inst = getInstance();
+        if (inst != null) {
+            for (Player plr : inst.getPlayers()) {
+                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+            }
+            inst.dispose();
+        }
+    }
+}

--- a/src/io/xeros/content/bosses/toa/SoloCrondis.java
+++ b/src/io/xeros/content/bosses/toa/SoloCrondis.java
@@ -1,0 +1,23 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.minigames.TOA.bosses.Crondis;
+import io.xeros.content.instances.InstancedArea;
+import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.player.Player;
+
+public class SoloCrondis extends Crondis {
+    public SoloCrondis(InstancedArea area) {
+        super(area);
+    }
+
+    @Override
+    public void onDeath() {
+        InstancedArea inst = getInstance();
+        if (inst != null) {
+            for (Player plr : inst.getPlayers()) {
+                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+            }
+            inst.dispose();
+        }
+    }
+}

--- a/src/io/xeros/content/bosses/toa/SoloKephri.java
+++ b/src/io/xeros/content/bosses/toa/SoloKephri.java
@@ -1,0 +1,23 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.minigames.TOA.bosses.Kephri;
+import io.xeros.content.instances.InstancedArea;
+import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.player.Player;
+
+public class SoloKephri extends Kephri {
+    public SoloKephri(InstancedArea area) {
+        super(area);
+    }
+
+    @Override
+    public void onDeath() {
+        InstancedArea inst = getInstance();
+        if (inst != null) {
+            for (Player plr : inst.getPlayers()) {
+                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+            }
+            inst.dispose();
+        }
+    }
+}

--- a/src/io/xeros/content/bosses/toa/SoloTumekensWarden.java
+++ b/src/io/xeros/content/bosses/toa/SoloTumekensWarden.java
@@ -1,0 +1,23 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.minigames.TOA.bosses.TumekensWarden;
+import io.xeros.content.instances.InstancedArea;
+import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.player.Player;
+
+public class SoloTumekensWarden extends TumekensWarden {
+    public SoloTumekensWarden(InstancedArea area) {
+        super(area);
+    }
+
+    @Override
+    public void onDeath() {
+        InstancedArea inst = getInstance();
+        if (inst != null) {
+            for (Player plr : inst.getPlayers()) {
+                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+            }
+            inst.dispose();
+        }
+    }
+}

--- a/src/io/xeros/content/bosses/toa/ToaInstance.java
+++ b/src/io/xeros/content/bosses/toa/ToaInstance.java
@@ -1,0 +1,39 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.instances.InstanceConfiguration;
+import io.xeros.content.instances.InstancedArea;
+import io.xeros.content.instances.InstanceConfigurationBuilder;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+
+import java.util.function.Function;
+
+public class ToaInstance extends InstancedArea {
+
+    private final Function<InstancedArea, NPC> bossSupplier;
+    private final Position spawnPosition;
+
+    private static final InstanceConfiguration CONFIG = new InstanceConfigurationBuilder()
+            .setCloseOnPlayersEmpty(true)
+            .setRespawnNpcs(false)
+            .createInstanceConfiguration();
+
+    public ToaInstance(Boundary boundary, Function<InstancedArea, NPC> bossSupplier, Position spawnPosition) {
+        super(CONFIG, boundary);
+        this.bossSupplier = bossSupplier;
+        this.spawnPosition = spawnPosition;
+    }
+
+    public void enter(Player player) {
+        add(player);
+        player.moveTo(new Position(spawnPosition.getX(), spawnPosition.getY(), getHeight()));
+        NPC npc = bossSupplier.apply(this);
+        npc.setPosition(new Position(spawnPosition.getX(), spawnPosition.getY(), getHeight()));
+        add(npc);
+    }
+
+    @Override
+    public void onDispose() { }
+}

--- a/src/io/xeros/content/bosses/toa/ToaInstances.java
+++ b/src/io/xeros/content/bosses/toa/ToaInstances.java
@@ -1,0 +1,56 @@
+package io.xeros.content.bosses.toa;
+
+import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+
+public class ToaInstances {
+
+    public static void startBaba(Player player) {
+        ToaInstance inst = new ToaInstance(
+                TombsOfAmascutConstants.BABA_BOSS_ROOM_BOUNDARY,
+                area -> new SoloBaba(area),
+                new Position(3808, 5406, 0));
+        inst.enter(player);
+    }
+
+    public static void startCrondis(Player player) {
+        ToaInstance inst = new ToaInstance(
+                TombsOfAmascutConstants.CRONDIS_BOSS_ROOM_BOUNDARY,
+                area -> new SoloCrondis(area),
+                new Position(3934, 5280, 0));
+        inst.enter(player);
+    }
+
+    public static void startApmeken(Player player) {
+        ToaInstance inst = new ToaInstance(
+                TombsOfAmascutConstants.APMEKEN1_BOSS_ROOM_BOUNDARY,
+                area -> new SoloApmeken(area),
+                new Position(3808, 5280, 0));
+        inst.enter(player);
+    }
+
+    public static void startAkkha(Player player) {
+        ToaInstance inst = new ToaInstance(
+                TombsOfAmascutConstants.AKKHA_BOSS_ROOM_BOUNDARY,
+                area -> new SoloAkkha(area),
+                new Position(3680, 5408, 1));
+        inst.enter(player);
+    }
+
+    public static void startKephri(Player player) {
+        ToaInstance inst = new ToaInstance(
+                TombsOfAmascutConstants.KEPHRI_BOSS_ROOM_BOUNDARY,
+                area -> new SoloKephri(area),
+                new Position(3550, 5408, 0));
+        inst.enter(player);
+    }
+
+    public static void startTumekensWarden(Player player) {
+        ToaInstance inst = new ToaInstance(
+                TombsOfAmascutConstants.TUMEKENS_WARDEN_BOSS_ROOM_BOUNDARY,
+                area -> new SoloTumekensWarden(area),
+                new Position(3816, 5152, 2));
+        inst.enter(player);
+    }
+}

--- a/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
@@ -27,7 +27,13 @@ public class BossInstanceDialogue extends DialogueBuilder {
                 optionFor(BossInstance.KRAKEN),
                 optionFor(BossInstance.CERBERUS),
                 optionFor(BossInstance.VORKATH),
-                optionFor(BossInstance.HYDRA));
+                optionFor(BossInstance.HYDRA),
+                optionFor(BossInstance.TOA_BABA),
+                optionFor(BossInstance.TOA_CRONDIS),
+                optionFor(BossInstance.TOA_APMEKEN),
+                optionFor(BossInstance.TOA_AKKHA),
+                optionFor(BossInstance.TOA_KEPHRI),
+                optionFor(BossInstance.TOA_TUMEKENS_WARDEN));
     }
 
     private void customMenu() {

--- a/src/io/xeros/content/instances/BossInstance.java
+++ b/src/io/xeros/content/instances/BossInstance.java
@@ -10,6 +10,7 @@ import io.xeros.content.bosses.hydra.AlchemicalHydra;
 import io.xeros.content.bosses.nightmare.NightmareInstance;
 import io.xeros.content.bosses.obor.OborInstance;
 import io.xeros.content.bosses.zulrah.Zulrah;
+import io.xeros.content.bosses.toa.ToaInstances;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 
@@ -28,7 +29,13 @@ public enum BossInstance {
     OBOR("Obor", 1_000_000, p -> new OborInstance().begin(p)),
     BRYOPHYTA("Bryophyta", 1_000_000, p -> new Bryophyta().enter(p)),
     DUKE_SUCELLUS("Duke Sucellus", 8_000_000, p -> { DukeSucellus inst = new DukeSucellus(p, Boundary.DUKE_INSTANCE); DukeSucellus.enter(p, inst); }),
-    NIGHTMARE("Nightmare", 10_000_000, p -> { NightmareInstance inst = new NightmareInstance(false); inst.add(p); inst.countdown(); });
+    NIGHTMARE("Nightmare", 10_000_000, p -> { NightmareInstance inst = new NightmareInstance(false); inst.add(p); inst.countdown(); }),
+    TOA_BABA("Baba", 5_000_000, ToaInstances::startBaba),
+    TOA_CRONDIS("Crondis", 5_000_000, ToaInstances::startCrondis),
+    TOA_APMEKEN("Apmeken", 5_000_000, ToaInstances::startApmeken),
+    TOA_AKKHA("Akkha", 5_000_000, ToaInstances::startAkkha),
+    TOA_KEPHRI("Kephri", 5_000_000, ToaInstances::startKephri),
+    TOA_TUMEKENS_WARDEN("Tumeken's Warden", 5_000_000, ToaInstances::startTumekensWarden);
 
     private final String name;
     private final long cost;


### PR DESCRIPTION
## Summary
- introduce new single-boss instances for Tombs of Amascut bosses
- extend `BossInstance` enum to include TOA bosses
- update `BossInstanceDialogue` to show the new tokens

## Testing
- `gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6889a2df2e64832095ac5e39c3aa5f10