### PR TITLE
Add dynamic tooltip export and client loader

### DIFF
--- a/src/com/client/draw/HoverManager.java
+++ b/src/com/client/draw/HoverManager.java
@@ -1,0 +1,306 @@
+package com.client.draw;
+
+import java.io.FileReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.client.Client;
+import com.client.Sprite;
+import com.client.engine.impl.MouseHandler;
+import com.client.definitions.ItemBonusDefinition;
+import com.client.definitions.ItemDefinition;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+public class HoverManager {
+
+    public static final int BACKGROUND_COLOUR = 0xFFFFFFF;
+
+    public static HashMap<Integer, HoverMenu> menus = new HashMap<>();
+
+    /**
+     * Load hover text from a json file dumped by the server.
+     */
+    public static void init() {
+        loadFromFile("item_tooltips.json");
+    }
+
+    private static void loadFromFile(String file) {
+        try (Reader reader = new FileReader(file)) {
+            Gson gson = new Gson();
+            Type type = new TypeToken<Map<String, String>>(){}.getType();
+            Map<String, String> data = gson.fromJson(reader, type);
+            for (Map.Entry<String, String> e : data.entrySet()) {
+                menus.put(Integer.parseInt(e.getKey()), new HoverMenu(e.getValue()));
+            }
+        } catch (Exception e) {
+            System.err.println("Unable to load hover menus: " + e.getMessage());
+        }
+        System.out.println("Turmoil has loaded " + menus.size() + "x menu hovers.");
+    }
+
+    public static int drawType() {
+        if (MouseHandler.mouseX > 0 && MouseHandler.mouseX < 500 && MouseHandler.mouseY > 0
+                && MouseHandler.mouseY < 300) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public static boolean shouldDraw(int id) {
+        return menus.get(id) != null;
+    }
+
+    public static boolean showMenu;
+
+    public static String hintName;
+
+    public static int hintId;
+
+    public static int displayIndex;
+
+    public static long displayDelay;
+
+    public static int[] itemDisplay = new int[4];
+
+    private static int lastDraw;
+
+    public static void reset() {
+        showMenu = false;
+        hintId = -1;
+        hintName = "";
+    }
+
+    public static boolean canDraw() {
+        if (Client.instance.menuActionRow < 2 && Client.instance.itemSelected == 0
+                && Client.instance.spellSelected == 0) {
+            return false;
+        }
+        if (Client.instance.getMenuManager().getMenuEntry(Client.instance.menuActionRow - 1) != null) {
+            if (Client.instance.getMenuManager().getMenuEntry(Client.instance.menuActionRow - 1).getOption().contains("Walk")) {
+                return false;
+            }
+        }
+        if (Client.instance.toolTip.contains("Walk") || Client.instance.toolTip.contains("World")) {
+            return false;
+        }
+        if (Client.instance.menuOpen) {
+            return false;
+        }
+        if (hintId == -1) {
+            return false;
+        }
+        if (!showMenu) {
+            return false;
+        }
+        return true;
+    }
+
+    public static void drawHintMenu() {
+        int mouseX = MouseHandler.mouseX;
+        int mouseY = MouseHandler.mouseY;
+
+        if (!canDraw()) {
+            return;
+        }
+
+        if (MouseHandler.mouseY < Client.canvasHeight - 450 && MouseHandler.mouseX < Client.canvasWidth - 200) {
+            return;
+        }
+        mouseX -= 100;
+        mouseY -= 50;
+
+        if (Client.controlIsDown) {
+            drawStatMenu();
+            return;
+        }
+
+        if (lastDraw != hintId) {
+            lastDraw = hintId;
+            itemDisplay = new int[4];
+        }
+
+        HoverMenu menu = menus.get(hintId);
+
+        if (menu != null) {
+            String text[] = split(menu.text, 20).split("\n");
+
+            int height = (text.length * 12) + (menu.items != null ? 40 : 0);
+
+            int width = (16 + text[0].length() * 5) + (menu.items != null ? 30 : 0);
+
+            Rasterizer2D.drawBoxOutline(mouseX, mouseY + 5, width + 4, 26 + height, 0x696969);
+            Rasterizer2D.drawTransparentBox(mouseX + 1, mouseY + 6, width + 2, 24 + height, 0x000000, 150);
+
+            Client.instance.newSmallFont.drawBasicString("@lre@" + hintName, (int) (mouseX + 4), mouseY + 19,
+                    BACKGROUND_COLOUR, 1);
+            int y = 0;
+
+            for (String string : text) {
+                Client.instance.newSmallFont.drawBasicString(string, mouseX + 4, mouseY + 35 + y, BACKGROUND_COLOUR, 1);
+                y += 12;
+            }
+
+            if (menu.items != null) {
+                int spriteX = 10;
+
+                if (System.currentTimeMillis() - displayDelay > 300) {
+                    displayDelay = System.currentTimeMillis();
+                    displayIndex++;
+                    if (displayIndex == menu.items.size()) {
+                        displayIndex = 0;
+                    }
+
+                    if (menu.items.size() <= 4) {
+                        for (int i = 0; i < menu.items.size(); i++) {
+                            itemDisplay[i] = menu.items.get(i);
+                        }
+                    } else {
+                        if (displayIndex >= menu.items.size() - 1) {
+                            displayIndex = menu.items.size() - 1;
+                        }
+                        int next = menu.items.get(displayIndex);
+                        for (int i = 0; i < itemDisplay.length - 1; i++) {
+                            itemDisplay[i] = itemDisplay[i + 1];
+                        }
+                        itemDisplay[3] = next;
+                    }
+                }
+
+                for (int id : itemDisplay) {
+                    if (id < 1) {
+                        continue;
+                    }
+                    Sprite item = ItemDefinition.getSprite(id, 1, 0);
+                    if (item != null) {
+                        item.drawSprite(mouseX + spriteX, mouseY + 35 + y);
+                        spriteX += 40;
+                    }
+                }
+            }
+            return;
+        }
+    }
+
+    public static void drawStatMenu() {
+        if (!canDraw()) {
+            return;
+        }
+
+        if(ItemBonusDefinition.getItemBonusDefinition(hintId) == null) {
+            HoverManager.reset();
+            return;
+        }
+
+        int mouseX = MouseHandler.mouseX;
+        int mouseY = MouseHandler.mouseY;
+
+        mouseX -= 100;
+        mouseY -= 50;
+
+        short stabAtk = ItemBonusDefinition.getItemBonuses(hintId)[0];
+        int slashAtk = ItemBonusDefinition.getItemBonuses(hintId)[1];
+        int crushAtk = ItemBonusDefinition.getItemBonuses(hintId)[2];
+        int magicAtk = ItemBonusDefinition.getItemBonuses(hintId)[3];
+        int rangedAtk = ItemBonusDefinition.getItemBonuses(hintId)[4];
+
+        int stabDef = ItemBonusDefinition.getItemBonuses(hintId)[5];
+        int slashDef = ItemBonusDefinition.getItemBonuses(hintId)[6];
+        int crushDef = ItemBonusDefinition.getItemBonuses(hintId)[7];
+        int magicDef = ItemBonusDefinition.getItemBonuses(hintId)[8];
+        int rangedDef = ItemBonusDefinition.getItemBonuses(hintId)[9];
+
+        int prayerBonus = ItemBonusDefinition.getItemBonuses(hintId)[11];
+        int strengthBonus = ItemBonusDefinition.getItemBonuses(hintId)[10];
+
+        Rasterizer2D.drawBoxOutline(mouseX, mouseY + 5, 150, 120, 0x696969);
+        Rasterizer2D.drawTransparentBox(mouseX + 1, mouseY + 6, 150, 121, 0x000000, 90);
+
+        Client.instance.newSmallFont.drawBasicString("@lre@" + hintName, mouseX + 4, mouseY + 18, BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("ATK:", mouseX + 62, mouseY + 30, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("DEF:", mouseX + 112, mouseY + 30, BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("Stab", mouseX + 2, mouseY + 43, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(stabAtk), mouseX + 62, mouseY + 43,
+                BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(stabDef), mouseX + 112, mouseY + 43,
+                BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("Slash", mouseX + 2, mouseY + 56, 0xFF00FF, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(slashAtk), mouseX + 62, mouseY + 56,
+                BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(slashDef), mouseX + 112, mouseY + 56,
+                BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("Crush", mouseX + 2, mouseY + 69, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(crushAtk), mouseX + 62, mouseY + 69,
+                BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(crushDef), mouseX + 112, mouseY + 69,
+                BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("Magic", mouseX + 2, mouseY + 80, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(magicAtk), mouseX + 62, mouseY + 80,
+                BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(magicDef), mouseX + 112, mouseY + 80,
+                BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("Ranged", mouseX + 2, mouseY + 95, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(rangedAtk), mouseX + 62, mouseY + 95,
+                BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(rangedDef), mouseX + 112, mouseY + 95,
+                BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("Strength", mouseX + 2, mouseY + 108, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("Prayer", mouseX + 2, mouseY + 121, BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(strengthBonus), mouseX + 112, mouseY + 108,
+                BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString(Integer.toString(prayerBonus), mouseX + 112, mouseY + 121,
+                BACKGROUND_COLOUR, 1);
+
+        Client.instance.newSmallFont.drawBasicString("Stab", mouseX + 2, mouseY + 43, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("Slash", mouseX + 2, mouseY + 56, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("Crush", mouseX + 2, mouseY + 69, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("Magic", mouseX + 2, mouseY + 80, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("Ranged", mouseX + 2, mouseY + 95, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("Strength", mouseX + 2, mouseY + 108, BACKGROUND_COLOUR, 1);
+        Client.instance.newSmallFont.drawBasicString("Prayer", mouseX + 2, mouseY + 121, BACKGROUND_COLOUR, 1);
+    }
+
+    private static String split(String text, int length) {
+        String string = "";
+
+        int size = 0;
+
+        for (String s : text.split(" ")) {
+            string += s + " ";
+            size += s.length();
+            if (size > length) {
+                string += "\n";
+                size = 0;
+            }
+        }
+        return string;
+    }
+
+    public static void drawHoverBox(RSFont font, int xPos, int yPos, String text, int colour, int backgroundColour) {
+        String[] results = text.split("\n");
+        int height = (results.length * 16) + 6;
+        int width;
+        width = font.getTextWidth(results[0]) + 6;
+        for (int i = 1; i < results.length; i++)
+            if (width <= font.getTextWidth(results[i]) + 6)
+                width = font.getTextWidth(results[i]) + 6;
+        Rasterizer2D.drawBox(xPos, yPos, width, height, backgroundColour);
+        Rasterizer2D.drawBoxOutline(xPos, yPos, width, height, 0);
+        yPos += 14;
+        for (int i = 0; i < results.length; i++) {
+            font.drawBasicString(results[i], xPos + 3, yPos, colour, 0);
+            yPos += 16;
+        }
+    }
+}
+

--- a/src/com/client/draw/HoverMenu.java
+++ b/src/com/client/draw/HoverMenu.java
@@ -1,0 +1,21 @@
+package com.client.draw;
+
+import java.util.List;
+
+/**
+ * Client side container for hover tooltip data.
+ */
+public class HoverMenu {
+    public final String text;
+    public final List<Integer> items;
+
+    public HoverMenu(String text) {
+        this(text, null);
+    }
+
+    public HoverMenu(String text, List<Integer> items) {
+        this.text = text;
+        this.items = items;
+    }
+}
+

--- a/src/io/xeros/content/menu/HoverMenu.java
+++ b/src/io/xeros/content/menu/HoverMenu.java
@@ -1,0 +1,16 @@
+package io.xeros.content.menu;
+
+/**
+ * Simple container for tooltip text displayed when hovering over an item.
+ */
+public class HoverMenu {
+    private final String text;
+
+    public HoverMenu(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/src/io/xeros/content/menu/ItemTooltips.java
+++ b/src/io/xeros/content/menu/ItemTooltips.java
@@ -1,0 +1,110 @@
+package io.xeros.content.menu;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.io.FileWriter;
+import java.io.IOException;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import io.xeros.content.fireofexchange.FireOfExchangeBurnPrice;
+import io.xeros.content.upgrade.UpgradeMaterials;
+import io.xeros.model.definitions.ItemDef;
+import io.xeros.util.Misc;
+
+import io.xeros.model.Items;
+
+/**
+ * Central registry of item tooltip text.
+ */
+public class ItemTooltips {
+
+    /**
+     * Map of item id to tooltip entry.
+     */
+    public static final Map<Integer, HoverMenu> MENUS = new HashMap<>();
+
+    static {
+        // Fire of Exchange burn values from the server definitions
+        for (int id = 0; id < 45_000; id++) {
+            int burn = FireOfExchangeBurnPrice.getBurnPrice(null, id, false);
+            if (burn > 0) {
+                MENUS.put(id, new HoverMenu("Dissolves in the Fire of Exchange for @lre@" +
+                        Misc.insertCommas(burn) + "@whi@ FOE."));
+            }
+        }
+
+        // Upgradeable items
+        for (UpgradeMaterials upgrade : UpgradeMaterials.values()) {
+            MENUS.put(upgrade.getRequired().getId(), new HoverMenu(
+                    "Upgrades into " + ItemDef.forId(upgrade.getReward().getId()).getName() +
+                            " for @lre@" + Misc.insertCommas((int) upgrade.getCost()) +
+                            "@whi@ coins (" + upgrade.getSuccessRate() + "% success)."));
+        }
+
+        // Item option effects
+        MENUS.put(Items.FISHING_PASS, new HoverMenu("Activates a membership pass when used."));
+        MENUS.put(11740, new HoverMenu("Teleports you to the Island activity when used."));
+        MENUS.put(Items.DWARVEN_ROCK_CAKE, new HoverMenu("Deals damage to lower your hitpoints (\"URGHHHHH!\")."));
+        MENUS.put(6644, new HoverMenu("Opens a crystal container and grants several reward items."));
+
+        // Herblore secondary ingredients
+        MENUS.put(145, new HoverMenu("Used to create Super Combat 3 potions."));  // Super attack(3)
+        MENUS.put(157, new HoverMenu("Used to create Super Combat 3 potions."));  // Super strength(3)
+        MENUS.put(163, new HoverMenu("Used to create Super Combat 3 potions."));  // Super defence(3)
+        MENUS.put(221, new HoverMenu("Used to create Attack, Super Attack potions."));  // Eye of newt
+        MENUS.put(223, new HoverMenu("Used to create Guthix Balance, Restore, Super Restore, Weapon Poison Plus potions."));  // Red spiders' eggs
+        MENUS.put(225, new HoverMenu("Used to create Strength, Super Strength potions."));  // Limpwurt root
+        MENUS.put(231, new HoverMenu("Used to create Fishing, Prayer potions."));  // Snape grass
+        MENUS.put(235, new HoverMenu("Used to create Antipoison, Sanfew 3, Sanfew 4, Super Antipoison potions."));  // Unicorn horn dust
+        MENUS.put(239, new HoverMenu("Used to create Defence, Super Defence potions."));  // White berries
+        MENUS.put(241, new HoverMenu("Used to create Antifire, Weapon Poison potions."));  // Dragon scale dust
+        MENUS.put(245, new HoverMenu("Used to create Ranging potions."));  // Wine of zamorak
+        MENUS.put(247, new HoverMenu("Used to create Zamorak Brew potions."));  // Jangerberries
+        MENUS.put(269, new HoverMenu("Used to create Anti Venom Plus potions."));  // Clean torstol
+        MENUS.put(1550, new HoverMenu("Used to create Guthix Balance potions."));  // Garlic
+        MENUS.put(1975, new HoverMenu("Used to create Energy potions."));  // Chocolate dust
+        MENUS.put(2152, new HoverMenu("Used to create Agility potions."));  // Toad's legs
+        MENUS.put(2398, new HoverMenu("Used to create Weapon Poison Plus Plus potions."));  // Nightshade
+        MENUS.put(2436, new HoverMenu("Used to create Super Combat 4 potions."));  // Super attack(4)
+        MENUS.put(2440, new HoverMenu("Used to create Super Combat 4 potions."));  // Super strength(4)
+        MENUS.put(2442, new HoverMenu("Used to create Super Combat 4 potions."));  // Super defence(4)
+        MENUS.put(2970, new HoverMenu("Used to create Super Energy potions."));  // Mort myre fungi
+        MENUS.put(3138, new HoverMenu("Used to create Magic potions."));  // Potato cactus
+        MENUS.put(6016, new HoverMenu("Used to create Weapon Poison Plus potions."));  // Cactus spine
+        MENUS.put(6018, new HoverMenu("Used to create Weapon Poison Plus Plus potions."));  // Poisonivy berries
+        MENUS.put(6049, new HoverMenu("Used to create Antidote Plus potions."));  // Yew roots
+        MENUS.put(6051, new HoverMenu("Used to create Antidote Plus Plus potions."));  // Magic roots
+        MENUS.put(6693, new HoverMenu("Used to create Saradomin Brew potions."));  // Crushed nest
+        MENUS.put(7650, new HoverMenu("Used to create Guthix Balance potions."));  // Silver dust
+        MENUS.put(9736, new HoverMenu("Used to create Combat potions."));  // Goat horn dust
+        MENUS.put(11994, new HoverMenu("Used to create Extended Antifire, Extended Super Antifire potions."));  // Lava scale shard
+        MENUS.put(12640, new HoverMenu("Used to create Stamina potions."));  // Amylase crystal
+        MENUS.put(12934, new HoverMenu("Used to create Anti Venom 1, Anti Venom 2, Anti Venom 3, Anti Venom 4 potions."));  // Zulrah's scales
+        MENUS.put(20698, new HoverMenu("Used to create Rejuv Pot potions."));  // Bruma herb
+        MENUS.put(21975, new HoverMenu("Used to create Super Antifire potions."));  // Crushed Superior Dragon dust
+        MENUS.put(23867, new HoverMenu("Used to create Divine Magic Potion 3, Divine Magic Potion 4, Divine Ranging Potion 3, Divine Ranging Potion 4, Divine Super Combat 3, Divine Super Combat 4 potions."));  // Crystal dust
+
+        // After populating the map, dump to json for clients
+        exportToJson("item_tooltips.json");
+    }
+
+    private ItemTooltips() {
+        // Utility class
+    }
+
+    /**
+     * Writes the current tooltip mapping to a JSON file so the client can load it.
+     */
+    public static void exportToJson(String file) {
+        try (FileWriter writer = new FileWriter(file)) {
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            Map<Integer, String> data = MENUS.entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getText()));
+            gson.toJson(data, writer);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- dump server-side item tooltips to `item_tooltips.json`
- add client HoverMenu and HoverManager that load hover text from the dumped JSON
- client hover drawing behaviour preserved

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6889ae60fb188320b1483668cc4384a5