### PR TITLE
Add respawning for TOA boss instances

### DIFF
--- a/src/io/xeros/content/bosses/toa/SoloAkkha.java
+++ b/src/io/xeros/content/bosses/toa/SoloAkkha.java
@@ -4,7 +4,11 @@ import io.xeros.content.minigames.TOA.bosses.Akkha;
 import io.xeros.content.instances.InstancedArea;
 import io.xeros.model.entity.Entity;
 import io.xeros.model.entity.player.Player;
-import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.content.item.lootable.impl.TombsOfAmascutChest;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+import java.util.List;
 
 public class SoloAkkha extends Akkha {
     public SoloAkkha(InstancedArea area) {
@@ -12,13 +16,19 @@ public class SoloAkkha extends Akkha {
     }
 
     @Override
+    public NPC provideRespawnInstance() {
+        return new SoloAkkha(getInstance());
+    }
+
+    @Override
     public void onDeath() {
         InstancedArea inst = getInstance();
         if (inst != null) {
+            Player rareWinner = Misc.random(inst.getPlayers());
             for (Player plr : inst.getPlayers()) {
-                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+                List<GameItem> rewards = TombsOfAmascutChest.getRandomItems(plr.equals(rareWinner), 1);
+                TombsOfAmascutChest.rewardItems(plr, rewards);
             }
-            inst.dispose();
         }
     }
 }

--- a/src/io/xeros/content/bosses/toa/SoloApmeken.java
+++ b/src/io/xeros/content/bosses/toa/SoloApmeken.java
@@ -2,8 +2,12 @@ package io.xeros.content.bosses.toa;
 
 import io.xeros.content.minigames.TOA.bosses.Apmeken;
 import io.xeros.content.instances.InstancedArea;
-import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.player.Player;
+import io.xeros.content.item.lootable.impl.TombsOfAmascutChest;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+import java.util.List;
 
 public class SoloApmeken extends Apmeken {
     public SoloApmeken(InstancedArea area) {
@@ -11,13 +15,19 @@ public class SoloApmeken extends Apmeken {
     }
 
     @Override
+    public NPC provideRespawnInstance() {
+        return new SoloApmeken(getInstance());
+    }
+
+    @Override
     public void onDeath() {
         InstancedArea inst = getInstance();
         if (inst != null) {
+            Player rareWinner = Misc.random(inst.getPlayers());
             for (Player plr : inst.getPlayers()) {
-                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+                List<GameItem> rewards = TombsOfAmascutChest.getRandomItems(plr.equals(rareWinner), 1);
+                TombsOfAmascutChest.rewardItems(plr, rewards);
             }
-            inst.dispose();
         }
     }
 }

--- a/src/io/xeros/content/bosses/toa/SoloBaba.java
+++ b/src/io/xeros/content/bosses/toa/SoloBaba.java
@@ -2,8 +2,12 @@ package io.xeros.content.bosses.toa;
 
 import io.xeros.content.minigames.TOA.bosses.Baba;
 import io.xeros.content.instances.InstancedArea;
-import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.player.Player;
+import io.xeros.content.item.lootable.impl.TombsOfAmascutChest;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+import java.util.List;
 
 public class SoloBaba extends Baba {
     public SoloBaba(InstancedArea area) {
@@ -11,13 +15,19 @@ public class SoloBaba extends Baba {
     }
 
     @Override
+    public NPC provideRespawnInstance() {
+        return new SoloBaba(getInstance());
+    }
+
+    @Override
     public void onDeath() {
         InstancedArea inst = getInstance();
         if (inst != null) {
+            Player rareWinner = Misc.random(inst.getPlayers());
             for (Player plr : inst.getPlayers()) {
-                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+                List<GameItem> rewards = TombsOfAmascutChest.getRandomItems(plr.equals(rareWinner), 1);
+                TombsOfAmascutChest.rewardItems(plr, rewards);
             }
-            inst.dispose();
         }
     }
 }

--- a/src/io/xeros/content/bosses/toa/SoloCrondis.java
+++ b/src/io/xeros/content/bosses/toa/SoloCrondis.java
@@ -2,8 +2,12 @@ package io.xeros.content.bosses.toa;
 
 import io.xeros.content.minigames.TOA.bosses.Crondis;
 import io.xeros.content.instances.InstancedArea;
-import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.player.Player;
+import io.xeros.content.item.lootable.impl.TombsOfAmascutChest;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+import java.util.List;
 
 public class SoloCrondis extends Crondis {
     public SoloCrondis(InstancedArea area) {
@@ -11,13 +15,19 @@ public class SoloCrondis extends Crondis {
     }
 
     @Override
+    public NPC provideRespawnInstance() {
+        return new SoloCrondis(getInstance());
+    }
+
+    @Override
     public void onDeath() {
         InstancedArea inst = getInstance();
         if (inst != null) {
+            Player rareWinner = Misc.random(inst.getPlayers());
             for (Player plr : inst.getPlayers()) {
-                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+                List<GameItem> rewards = TombsOfAmascutChest.getRandomItems(plr.equals(rareWinner), 1);
+                TombsOfAmascutChest.rewardItems(plr, rewards);
             }
-            inst.dispose();
         }
     }
 }

--- a/src/io/xeros/content/bosses/toa/SoloKephri.java
+++ b/src/io/xeros/content/bosses/toa/SoloKephri.java
@@ -2,8 +2,12 @@ package io.xeros.content.bosses.toa;
 
 import io.xeros.content.minigames.TOA.bosses.Kephri;
 import io.xeros.content.instances.InstancedArea;
-import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.player.Player;
+import io.xeros.content.item.lootable.impl.TombsOfAmascutChest;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+import java.util.List;
 
 public class SoloKephri extends Kephri {
     public SoloKephri(InstancedArea area) {
@@ -11,13 +15,19 @@ public class SoloKephri extends Kephri {
     }
 
     @Override
+    public NPC provideRespawnInstance() {
+        return new SoloKephri(getInstance());
+    }
+
+    @Override
     public void onDeath() {
         InstancedArea inst = getInstance();
         if (inst != null) {
+            Player rareWinner = Misc.random(inst.getPlayers());
             for (Player plr : inst.getPlayers()) {
-                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+                List<GameItem> rewards = TombsOfAmascutChest.getRandomItems(plr.equals(rareWinner), 1);
+                TombsOfAmascutChest.rewardItems(plr, rewards);
             }
-            inst.dispose();
         }
     }
 }

--- a/src/io/xeros/content/bosses/toa/SoloTumekensWarden.java
+++ b/src/io/xeros/content/bosses/toa/SoloTumekensWarden.java
@@ -2,8 +2,12 @@ package io.xeros.content.bosses.toa;
 
 import io.xeros.content.minigames.TOA.bosses.TumekensWarden;
 import io.xeros.content.instances.InstancedArea;
-import io.xeros.content.minigames.TOA.TombsOfAmascutConstants;
+import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.player.Player;
+import io.xeros.content.item.lootable.impl.TombsOfAmascutChest;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+import java.util.List;
 
 public class SoloTumekensWarden extends TumekensWarden {
     public SoloTumekensWarden(InstancedArea area) {
@@ -11,13 +15,19 @@ public class SoloTumekensWarden extends TumekensWarden {
     }
 
     @Override
+    public NPC provideRespawnInstance() {
+        return new SoloTumekensWarden(getInstance());
+    }
+
+    @Override
     public void onDeath() {
         InstancedArea inst = getInstance();
         if (inst != null) {
+            Player rareWinner = Misc.random(inst.getPlayers());
             for (Player plr : inst.getPlayers()) {
-                plr.moveTo(TombsOfAmascutConstants.FINISHED_TOMBS_OF_AMASCUT_POSITION);
+                List<GameItem> rewards = TombsOfAmascutChest.getRandomItems(plr.equals(rareWinner), 1);
+                TombsOfAmascutChest.rewardItems(plr, rewards);
             }
-            inst.dispose();
         }
     }
 }

--- a/src/io/xeros/content/bosses/toa/ToaInstance.java
+++ b/src/io/xeros/content/bosses/toa/ToaInstance.java
@@ -17,7 +17,7 @@ public class ToaInstance extends InstancedArea {
 
     private static final InstanceConfiguration CONFIG = new InstanceConfigurationBuilder()
             .setCloseOnPlayersEmpty(true)
-            .setRespawnNpcs(false)
+            .setRespawnNpcs(true)
             .createInstanceConfiguration();
 
     public ToaInstance(Boundary boundary, Function<InstancedArea, NPC> bossSupplier, Position spawnPosition) {
@@ -31,7 +31,8 @@ public class ToaInstance extends InstancedArea {
         player.moveTo(new Position(spawnPosition.getX(), spawnPosition.getY(), getHeight()));
         NPC npc = bossSupplier.apply(this);
         npc.setPosition(new Position(spawnPosition.getX(), spawnPosition.getY(), getHeight()));
-        add(npc);
+        npc.getBehaviour().setRespawn(true);
+        npc.getBehaviour().setRespawnWhenPlayerOwned(true);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- enable respawning NPCs in ToA single-boss instances
- mark spawned ToA bosses as respawnable
- grant TOA chest rewards when an instance boss dies
- implement custom respawn instances for solo ToA bosses
- avoid duplicate NPC entries when spawning bosses

## Testing
- `gradle test --no-daemon` *(fails: could not compile project)*

------
https://chatgpt.com/codex/tasks/task_e_688abd7bd5f88320b7845ae488f81cbd