### PR TITLE
Enable vote panel & enhance voting rewards

### DIFF
--- a/src/io/xeros/Configuration.java
+++ b/src/io/xeros/Configuration.java
@@ -121,7 +121,11 @@ public class Configuration {
 	 */
 	public static boolean BOUNTY_HUNTER_ACTIVE = true;
 	public static boolean NEW_DUEL_ARENA_ACTIVE = true;
-	public static boolean VOTE_PANEL_ACTIVE = false;
+        /**
+         * Toggles the weekly vote panel system. When enabled players can
+         * access ::vpanel to track streaks and claim extra rewards.
+         */
+        public static boolean VOTE_PANEL_ACTIVE = true;
 
 	/**
 	 * The highest amount ID. Change is not needed here unless loading items higher


### PR DESCRIPTION
## Summary
- turn on vote panel
- double GP reward and point gains from voting
- extend bonus XP from votes to one hour
- award double vote crystals when claiming votes
- ensure vote panel streaks save and update on `::voted`

## Testing
- `gradle build -x test` *(fails: cannot find symbol: various classes)*

------
https://chatgpt.com/codex/tasks/task_e_688bc4dcb188832099d8f2ce60b47eba