### PR TITLE
Fix AOE attack targeting

### DIFF
--- a/src/io/xeros/content/combat/core/AttackNpcCheck.java
+++ b/src/io/xeros/content/combat/core/AttackNpcCheck.java
@@ -39,6 +39,10 @@ public class AttackNpcCheck {
     public static boolean check(Player c, Entity targetEntity, boolean sendMessages) {
         NPC npc = targetEntity.asNPC();
         int levelRequired;
+        // Prevent attacking NPCs that are not in the player's instance
+        if (c.getInstance() != npc.getInstance()) {
+            return false;
+        }
         if (npc == null || npc.getHealth().getMaximumHealth() == 0) {
             return false;
         }

--- a/src/io/xeros/content/commands/all/Bossinstance.java
+++ b/src/io/xeros/content/commands/all/Bossinstance.java
@@ -1,0 +1,28 @@
+package io.xeros.content.commands.all;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.dialogue.impl.BossInstanceDialogue;
+import io.xeros.model.entity.player.Player;
+
+import java.util.Optional;
+
+/**
+ * Opens the boss instance dialogue so players can manage their personal boss tiers.
+ */
+public class Bossinstance extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        player.start(new BossInstanceDialogue(player));
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("Opens the boss instance menu.");
+    }
+}

--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -1,0 +1,156 @@
+package io.xeros.content.instances;
+
+import io.xeros.content.instances.InstanceConfiguration;
+import io.xeros.content.instances.impl.LegacySoloPlayerInstance;
+import io.xeros.model.Npcs;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.npc.NPCSpawning;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Player;
+
+import java.util.Map;
+
+/**
+ * Simple manager for personal boss instances. Each player that enters a zone
+ * receives their own height level so spawned NPCs are only visible to them.
+ */
+public class BossInstanceManager {
+
+    /** Mapping of players to their active instance. */
+    private static final Map<Player, BossInstanceArea> INSTANCES = new java.util.concurrent.ConcurrentHashMap<>();
+
+    /**
+     * Simple instance type that cleans up the instance map when disposed so
+     * height levels can be reused immediately.
+     */
+    private static class BossInstanceArea extends LegacySoloPlayerInstance {
+
+        /** Player that owns this instance. */
+        private final Player owner;
+
+        BossInstanceArea(Player owner, Boundary boundary) {
+            super(InstanceConfiguration.CLOSE_ON_EMPTY, owner, boundary);
+            this.owner = owner;
+        }
+
+        @Override
+        public void onDispose() {
+            INSTANCES.remove(owner);
+        }
+    }
+
+    /**
+     * Difficulty tiers for bosses.
+     */
+    public enum BossTier {
+        TIER1("Training Grounds", 0, 0, -1, new int[]{Npcs.COW}),
+        TIER2("Giants' Den", 10, 100_000, -1, new int[]{Npcs.HILL_GIANT}),
+        TIER3("Dragon Lair", 50, 1_000_000, 11286, new int[]{Npcs.KING_BLACK_DRAGON});
+
+        private final String zoneName;
+        /** Kill requirement to unlock this tier. */
+        private final int killRequirement;
+        /** GP cost to unlock the tier. */
+        private final int gpCost;
+        /** Optional item requirement (-1 if none). */
+        private final int itemRequirement;
+        private final int[] npcIds;
+
+        BossTier(String zoneName, int killRequirement, int gpCost, int itemRequirement, int[] npcIds) {
+            this.zoneName = zoneName;
+            this.killRequirement = killRequirement;
+            this.gpCost = gpCost;
+            this.itemRequirement = itemRequirement;
+            this.npcIds = npcIds;
+        }
+
+        public String getZoneName() {
+            return zoneName;
+        }
+
+        public int getKillRequirement() {
+            return killRequirement;
+        }
+
+        public int getGpCost() {
+            return gpCost;
+        }
+
+        public int getItemRequirement() {
+            return itemRequirement;
+        }
+
+        public int[] getNpcIds() {
+            return npcIds;
+        }
+    }
+
+    /**
+     * Enter a boss instance for the given tier. A new height level is reserved
+     * for the player and the appropriate NPCs are spawned for them only.
+     */
+    public static void enter(Player player, BossTier tier) {
+        if (INSTANCES.containsKey(player)) {
+            player.sendMessage("You are already inside a boss instance.");
+            return;
+        }
+
+        if (!player.getUnlockedBossTiers().contains(tier)) {
+            player.sendMessage("You haven't unlocked this tier yet.");
+            return;
+        }
+
+        // Small boundary around the player so instance cleanup works.
+        Boundary bounds = new Boundary(player.getX() - 10, player.getY() - 10,
+                player.getX() + 10, player.getY() + 10);
+
+        BossInstanceArea instance = new BossInstanceArea(player, bounds);
+        INSTANCES.put(player, instance);
+
+        instance.add(player);
+        player.getPA().movePlayerUnconditionally(player.getX(), player.getY(), instance.getHeight());
+
+        spawnNpcs(player, tier, instance);
+    }
+
+    /**
+     * Spawn all NPCs for a player's boss instance. NPCs are spaced out using a
+     * simple grid so they don't overlap and are only visible to the owner.
+     */
+    private static void spawnNpcs(Player player, BossTier tier, BossInstanceArea instance) {
+        int baseX = player.getX();
+        int baseY = player.getY();
+
+        int[] ids = tier.getNpcIds();
+        for (int index = 0; index < ids.length; index++) {
+            int npcId = ids[index];
+
+            // Spread NPCs out using a 3xN grid with 2 tile spacing
+            int offsetX = (index % 3) * 2;
+            int offsetY = (index / 3) * 2;
+
+            NPC npc = NPCSpawning.spawnNpc(player, npcId, baseX + offsetX, baseY + offsetY,
+                    instance.getHeight(), 0, 0, false, false);
+            if (npc != null) {
+                npc.getBehaviour().setRespawn(false);
+                instance.add(npc);
+            }
+        }
+    }
+
+    /**
+     * Leave the boss instance, disposing of any spawned NPCs and freeing the
+     * height level.
+     */
+    public static void leave(Player player) {
+        BossInstanceArea instance = INSTANCES.remove(player);
+        if (instance != null) {
+            instance.dispose();
+            player.getPA().movePlayerUnconditionally(player.getX(), player.getY(), 0);
+        }
+    }
+
+    public static BossInstanceArea get(Player player) {
+        return INSTANCES.get(player);
+    }
+}

--- a/src/io/xeros/content/items/aoeweapons/AoeManager.java
+++ b/src/io/xeros/content/items/aoeweapons/AoeManager.java
@@ -36,53 +36,37 @@ public class AoeManager {
 //        }
 
         AoeWeapons aoeData = AOESystem.getSingleton().getAOEData(player.playerEquipment[Player.playerWeapon]);
-        if (aoeData != null) {
+        if (aoeData == null) {
+            return;
+        }
 
-            int dmg = Misc.random(aoeData.DMG);
-            int range = aoeData.Size;
-            int delay = aoeData.Delay;
-            int anim = aoeData.anim;
-            int gfx = aoeData.gfx;
-            String style = aoeData.style;
+        int dmg = Misc.random(aoeData.DMG);
+        int range = aoeData.Size;
+        int delay = aoeData.Delay;
+        int anim = aoeData.anim;
+        int gfx = aoeData.gfx;
+        String style = aoeData.style;
 
-            player.startAnimation(anim);
+        player.startAnimation(anim);
 
-            Iterator<NPC> it;
-            if (player.isPlayer() && victim.isNPC()) {
-//                it = Arrays.stream(NPCHandler.npcs).filter(i -> i.getPosition().withinDistance(player.getPosition(), range)).iterator();
-                for (NPC next : NPCHandler.npcs) {
-                    if (next != null) {
-                        if (player.getPosition().withinDistance(next.getPosition(), range) && next.getHealth().getCurrentHealth() > 0) {
-                            if (next.isNPC() && next.getHealth().getCurrentHealth() <= 0 && next.isDead()) {
-                                continue;
-                            }
-                            if (victim != next) {
-                                victim.startGraphic(new Graphic(gfx, 0, Graphic.GraphicHeight.MIDDLE));
-                                int calc = Misc.random(dmg);
-                                victim.appendDamage(player, calc, (calc > 0 ? Hitmark.HIT : Hitmark.MISS));
-                            }
-//                            if (Objects.equals(style, "mage")) {
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, Skill.MAGIC.getId(), true);
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, 3, true);
-//                            } else if (Objects.equals(style, "melee")) {
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, 0, true);
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, 1, true);
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, 2, true);
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, 3, true);
-//                            } else if (Objects.equals(style, "ranged")) {
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, 4, true);
-//                                player.getPA().addSkillXPMultiplied(dmg >> 2, 3, true);
-//                            }
-//                            RangeData.fireProjectileNpc(player, next.asNPC(), 50, 70, gfx, 43, 31, 37, 10);
-                            next.startGraphic(new Graphic(gfx, 0, Graphic.GraphicHeight.MIDDLE));
-                            int calc = Misc.random(dmg);
-                            next.appendDamage(player, calc, (calc > 0 ? Hitmark.HIT : Hitmark.MISS));
-                            next.attackEntity(player);
-                            player.attackTimer = delay;
-                        }
-                    }
+        if (player.isPlayer() && victim.isNPC()) {
+            victim.startGraphic(new Graphic(gfx, 0, Graphic.GraphicHeight.MIDDLE));
+            for (NPC next : NPCHandler.npcs) {
+                if (next == null) {
+                    continue;
                 }
+                if (next.getInstance() != player.getInstance() || next.getHeight() != player.getHeight()) {
+                    continue;
+                }
+                if (!player.getPosition().withinDistance(next.getPosition(), range) || next.getHealth().getCurrentHealth() <= 0) {
+                    continue;
+                }
+                next.startGraphic(new Graphic(gfx, 0, Graphic.GraphicHeight.MIDDLE));
+                int calc = Misc.random(dmg);
+                next.appendDamage(player, calc, (calc > 0 ? Hitmark.HIT : Hitmark.MISS));
+                next.attackEntity(player);
             }
+            player.attackTimer = delay;
         }
     }
 }

--- a/src/io/xeros/model/entity/npc/NPC.java
+++ b/src/io/xeros/model/entity/npc/NPC.java
@@ -1396,6 +1396,9 @@ public class NPC extends Entity {
     public void appendDamage(Entity entity, int damage, Hitmark hitmark) {
         if (entity != null && entity.isPlayer()) {
             Player player = (Player) entity;
+            if (player.getInstance() != getInstance()) {
+                return;
+            }
             damage = modifyDamage(player, damage);
             if (!canBeDamaged(player)) {
                 damage = 0;

--- a/src/io/xeros/model/entity/player/Player.java
+++ b/src/io/xeros/model/entity/player/Player.java
@@ -831,6 +831,10 @@ public class Player extends Entity {
      * Boss instances the player has unlocked.
      */
     private java.util.EnumSet<io.xeros.content.instances.BossInstance> unlockedInstances = java.util.EnumSet.noneOf(io.xeros.content.instances.BossInstance.class);
+    /**
+     * Boss tiers unlocked for {@link io.xeros.content.instances.BossInstanceManager}.
+     */
+    private java.util.EnumSet<io.xeros.content.instances.BossInstanceManager.BossTier> unlockedBossTiers = java.util.EnumSet.of(io.xeros.content.instances.BossInstanceManager.BossTier.TIER1);
     public int totalEarnedExchangePoints;
     public int referallFlag;
     public int amDonated;
@@ -6213,6 +6217,13 @@ public class Player extends Entity {
      */
     public java.util.EnumSet<io.xeros.content.instances.BossInstance> getUnlockedInstances() {
         return unlockedInstances;
+    }
+
+    /**
+     * Get the set of unlocked boss tiers.
+     */
+    public java.util.EnumSet<io.xeros.content.instances.BossInstanceManager.BossTier> getUnlockedBossTiers() {
+        return unlockedBossTiers;
     }
 
     public BlastFurnace getBlastFurnace() {

--- a/src/io/xeros/model/entity/player/save/PlayerSave.java
+++ b/src/io/xeros/model/entity/player/save/PlayerSave.java
@@ -1114,6 +1114,16 @@ public class PlayerSave {
                                         e.printStackTrace();
                                     }
                                 }
+                            } else if (token.equals("tier-unlocks")) {
+                                for (String s : token3) {
+                                    try {
+                                        io.xeros.content.instances.BossInstanceManager.BossTier tier = io.xeros.content.instances.BossInstanceManager.BossTier.valueOf(s);
+                                        p.getUnlockedBossTiers().add(tier);
+                                    } catch (Exception e) {
+                                        logger.error("Error while loading {}", playerName, e);
+                                        e.printStackTrace();
+                                    }
+                                }
                             } else if (token.startsWith("removedTask")) {
                                 int value = Integer.parseInt(token2);
                                 if (value > -1) {
@@ -1743,6 +1753,17 @@ public class PlayerSave {
                 for (io.xeros.content.instances.BossInstance bi : p.getUnlockedInstances()) {
                     characterfile.write(bi.name());
                     if (i++ < p.getUnlockedInstances().size() - 1) {
+                        characterfile.write("\t");
+                    }
+                }
+            }
+            characterfile.newLine();
+            if (!p.getUnlockedBossTiers().isEmpty()) {
+                characterfile.write("tier-unlocks = ");
+                int i = 0;
+                for (io.xeros.content.instances.BossInstanceManager.BossTier tier : p.getUnlockedBossTiers()) {
+                    characterfile.write(tier.name());
+                    if (i++ < p.getUnlockedBossTiers().size() - 1) {
                         characterfile.write("\t");
                     }
                 }


### PR DESCRIPTION
## Summary
- spawn personal boss NPCs in instances
- scope AOE attack loops to the attacking player's instance
- disallow attacking NPCs from another instance
- ignore damage to NPCs from players in different instances
- add BossInstanceDialogue for unlocking instance tiers
- persist unlocked boss tiers on the player save
- block instance entry if the tier isn't unlocked
- add `::bossinstance` command to open the instance menu
- optimize BossInstanceManager cleanup

## Testing
- `gradle test -q` *(fails to compile due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_688bd50bea9c83208264c9d41067020a