### PR TITLE
Add boss instance kill overlay

### DIFF
--- a/src/io/xeros/content/combat/death/NPCDeath.java
+++ b/src/io/xeros/content/combat/death/NPCDeath.java
@@ -14,6 +14,7 @@ import io.xeros.content.bosses.nightmare.NightmareConstants;
 import io.xeros.content.bosses.wildypursuit.FragmentOfSeren;
 import io.xeros.content.bosses.wildypursuit.TheUnbearable;
 import io.xeros.content.bosspoints.BossPoints;
+import io.xeros.content.instances.BossInstanceUIManager;
 import io.xeros.content.combat.Hitmark;
 import io.xeros.content.event.eventcalendar.EventChallenge;
 import io.xeros.content.events.monsterhunt.MonsterHunt;
@@ -353,6 +354,7 @@ public class NPCDeath {
                     player.sendMessage("\uD83C\uDF89 You've unlocked " + next.name().replace('_', ' ') + "! Return to the instance portal to challenge new bosses!");
                 }
             }
+            BossInstanceUIManager.sendKillOverlay(player);
         }
 
         if (NpcDef.forId(npcId).getCombatLevel() >= 1) {

--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -228,6 +228,7 @@ public class BossInstanceManager {
         player.getPA().movePlayerUnconditionally(player.getX(), player.getY(), instance.getHeight());
 
         spawnNpcs(player, tier, instance);
+        BossInstanceUIManager.sendKillOverlay(player);
     }
 
     /**

--- a/src/io/xeros/content/instances/BossInstanceUIManager.java
+++ b/src/io/xeros/content/instances/BossInstanceUIManager.java
@@ -1,0 +1,31 @@
+package io.xeros.content.instances;
+
+import io.xeros.model.entity.player.Player;
+
+/**
+ * Handles displaying boss instance progress information to players.
+ */
+public class BossInstanceUIManager {
+
+    /**
+     * Sends an overlay to the player showing their current tier progress.
+     * Displays the tier name, current kill count within the tier, and the next
+     * tier that will be unlocked.
+     */
+    public static void sendKillOverlay(Player player) {
+        BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(player);
+        if (area == null) {
+            return;
+        }
+
+        BossInstanceManager.BossTier tier = area.getTier();
+        int current = player.getTierKillCounts().getOrDefault(tier, 0);
+        int required = tier.getRequiredKillCountToUnlockNext();
+        BossInstanceManager.BossTier next = tier.getNextTier();
+        String nextName = next != null ? next.name().replace('_', ' ') : "Maxed";
+
+        player.sendMessage("\uD83E\uDDF1 Tier: " + tier.name().replace('_', ' '));
+        player.sendMessage("\u2620\uFE0F Kills: " + current + " / " + required);
+        player.sendMessage("\uD83D\uDD13 Unlocks: " + nextName);
+    }
+}


### PR DESCRIPTION
## Summary
- show boss instance tier, kill count and next unlock for player via `BossInstanceUIManager.sendKillOverlay`
- call overlay on boss instance entry
- refresh overlay after each kill in an instance

## Testing
- `gradle test` *(fails: package io.xeros.content.pet does not exist, package io.xeros.content.bosses.Solak does not exist, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688e520887908320bec2b5a8fc717670