### PR TITLE
feat: support bulk clue casket opening

### DIFF
--- a/src/io/xeros/content/trails/ClueCasketHandler.java
+++ b/src/io/xeros/content/trails/ClueCasketHandler.java
@@ -1,0 +1,147 @@
+package io.xeros.content.trails;
+
+import io.xeros.content.achievement.AchievementType;
+import io.xeros.content.achievement.Achievements;
+import io.xeros.model.Items;
+import io.xeros.model.definitions.ItemDef;
+import io.xeros.model.entity.npc.pets.PetHandler;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+
+import java.util.*;
+
+public class ClueCasketHandler {
+
+    public static boolean bulkOpenCasket(Player player, int itemId, int amount) {
+        RewardLevel level = null;
+        boolean isCasket = false;
+        for (RewardLevel rl : RewardLevel.values()) {
+            if (rl.getCasketId() == itemId) {
+                level = rl;
+                isCasket = true;
+                break;
+            }
+            if (rl.getClueScrollId() == itemId) {
+                level = rl;
+                break;
+            }
+        }
+        if (level == null) {
+            return false;
+        }
+
+        int owned = player.getItems().getItemAmount(itemId);
+        amount = Math.min(amount, owned);
+        if (amount <= 0) {
+            return false;
+        }
+
+        if (!isCasket) {
+            openScrolls(player, level, amount);
+            return true;
+        }
+
+        openCaskets(player, level, itemId, amount);
+        return true;
+    }
+
+    private static void openScrolls(Player player, RewardLevel level, int amount) {
+        int mimic = 0;
+        int caskets = 0;
+        for (int i = 0; i < amount; i++) {
+            Achievements.increase(player, AchievementType.CLUES, 1);
+            player.getItems().deleteItem(level.getClueScrollId(), 1);
+            if (TreasureTrails.rollMimicCasket(level)) {
+                mimic++;
+            } else {
+                caskets++;
+            }
+        }
+        if (mimic > 0) {
+            player.getItems().addItem(Items.MIMIC, mimic);
+            player.sendMessage("You've received " + mimic + " Mimic casket" + (mimic > 1 ? "s" : "") + "!");
+        }
+        if (caskets > 0) {
+            player.getItems().addItem(level.getCasketId(), caskets);
+            player.sendMessage("You've received " + caskets + " " + level.getFormattedName() + " clue scroll casket" + (caskets > 1 ? "s" : "") + ".");
+        }
+    }
+
+    private static void openCaskets(Player player, RewardLevel level, int itemId, int amount) {
+        Map<Integer, Integer> rewards = new HashMap<>();
+        Set<Integer> announced = new HashSet<>();
+        int opened = 0;
+        int extraCaskets = 0;
+
+        for (int i = 0; i < amount; i++) {
+            if (player.getItems().freeSlots() < 3) {
+                player.sendMessage("You need at least 3 free slots to open this.");
+                break;
+            }
+            opened++;
+            player.getItems().deleteItem(itemId, 1);
+            List<GameItem> list = player.getTrails().generateRewardList(level, 1 + Misc.random(2), false);
+            for (GameItem gi : list) {
+                rewards.merge(gi.getId(), gi.getAmount(), Integer::sum);
+                if (isRare(gi)) {
+                    announced.add(gi.getId());
+                }
+            }
+            if (player.getPerkSytem().gameItems.stream().anyMatch(it -> it.getId() == 33114) && Misc.isLucky(5)) {
+                extraCaskets++;
+            }
+        }
+
+        if (opened == 0) {
+            return;
+        }
+
+        List<GameItem> rewardList = new ArrayList<>();
+        for (Map.Entry<Integer, Integer> entry : rewards.entrySet()) {
+            rewardList.add(new GameItem(entry.getKey(), entry.getValue()));
+            if (player.getItems().playerHasItem(19730) || player.hasFollower && player.petSummonId == 19730) {
+                player.getItems().addItemToBankOrDrop(entry.getKey(), entry.getValue());
+            } else {
+                player.getItems().addItemUnderAnyCircumstance(entry.getKey(), entry.getValue());
+            }
+        }
+        player.getTrails().displayRewards(rewardList);
+        for (int id : announced) {
+            TreasureTrails.announceRare(player, new GameItem(id, rewards.get(id)), level);
+        }
+        if (extraCaskets > 0) {
+            player.getItems().addItemUnderAnyCircumstance(itemId, extraCaskets);
+            player.sendMessage("@red@You manage to get another clue casket x" + extraCaskets + "!!");
+        }
+
+        switch (level) {
+            case EASY:
+                player.setEasyClueCounter(player.getEasyClueCounter() + opened);
+                player.sendMessage("<col=2d256d>You have completed " + player.getEasyClueCounter() + " Easy Treasure Trails.");
+                break;
+            case MEDIUM:
+                player.setMediumClueCounter(player.getMediumClueCounter() + opened);
+                player.sendMessage("<col=2d256d>You have completed " + player.getMediumClueCounter() + " medium Treasure Trails.");
+                break;
+            case HARD:
+                player.setHardClueCounter(player.getHardClueCounter() + opened);
+                player.sendMessage("<col=2d256d>You have completed " + player.getHardClueCounter() + " hard Treasure Trails.");
+                break;
+            case MASTER:
+                player.setMasterClueCounter(player.getMasterClueCounter() + opened);
+                player.sendMessage("<col=2d256d>You have completed " + player.getMasterClueCounter() + " master Treasure Trails.");
+                for (int i = 0; i < opened; i++) {
+                    PetHandler.roll(player, PetHandler.Pets.BLOODHOUND);
+                }
+                break;
+        }
+        player.sendMessage("You open x" + opened + " " + level.getFormattedName() + " caskets...");
+    }
+
+    private static boolean isRare(GameItem item) {
+        String name = ItemDef.forId(item.getId()).getName();
+        return name.contains("3rd") || item.getId() == 2577 || name.contains("mage's");
+    }
+}
+

--- a/src/io/xeros/content/trails/TreasureTrails.java
+++ b/src/io/xeros/content/trails/TreasureTrails.java
@@ -52,7 +52,7 @@ public class TreasureTrails {
 		return 0;
 	}
 
-	private static void announceRare(Player player, GameItem item, RewardLevel difficulty) {
+        public static void announceRare(Player player, GameItem item, RewardLevel difficulty) {
 		PlayerHandler.executeGlobalMessage("[<col=CC0000>Treasure</col>] <col=255>" + player.getDisplayNameFormatted() + "</col> " +
 				"<col=CC0000>received " +
 				"<col=255>" + ItemDef.forId(item.getId()).getName() + "</col> " +
@@ -69,24 +69,29 @@ public class TreasureTrails {
 	 * This method is used by clues.
 	 * Rolls=1+rand(1, 2)
 	 */
-	public List<GameItem> generateRewardList(RewardLevel rewardLevel) {
-		return generateRewardList(rewardLevel, 1 + Misc.random(2));
-	}
+        public List<GameItem> generateRewardList(RewardLevel rewardLevel) {
+                return generateRewardList(rewardLevel, 1 + Misc.random(2), true);
+        }
 
-	/**
-	 * This will generate the drop list, globally announce rares and update collection log. It's assumed
-	 * that you will be dropped/adding these items immediately after calling!
-	 * @param rewardLevel The {@link RewardLevel}
-	 * @return List of random items.
-	 */
-	public List<GameItem> generateRewardList(RewardLevel rewardLevel, int rolls) {
-		player.getNpcDeathTracker().add(Misc.optimizeText(rewardLevel.name().toLowerCase()), -1, 0);
-		List<GameItem> rewards = TreasureTrailsRewards.getRandomRewardItems(rewardLevel, rolls);
+        public List<GameItem> generateRewardList(RewardLevel rewardLevel, int rolls) {
+                return generateRewardList(rewardLevel, rolls, true);
+        }
 
-		for (GameItem item : rewards) {
-			if (ItemDef.forId(item.getId()).getName().contains("3rd") || item.getId() == 2577 || ItemDef.forId(item.getId()).getName().contains("mage's")) {
-				announceRare(player, item, rewardLevel);
-			}
+        /**
+         * This will generate the drop list, optionally globally announce rares and update collection log. It's assumed
+         * that you will be dropped/adding these items immediately after calling!
+         * @param rewardLevel The {@link RewardLevel}
+         * @param announce should global announcements be sent for rare items
+         * @return List of random items.
+         */
+        public List<GameItem> generateRewardList(RewardLevel rewardLevel, int rolls, boolean announce) {
+                player.getNpcDeathTracker().add(Misc.optimizeText(rewardLevel.name().toLowerCase()), -1, 0);
+                List<GameItem> rewards = TreasureTrailsRewards.getRandomRewardItems(rewardLevel, rolls);
+
+                for (GameItem item : rewards) {
+                        if (announce && (ItemDef.forId(item.getId()).getName().contains("3rd") || item.getId() == 2577 || ItemDef.forId(item.getId()).getName().contains("mage's"))) {
+                                announceRare(player, item, rewardLevel);
+                        }
 
 			if (TreasureTrailsRewards.possibleDrops.get(rewardLevel).stream().anyMatch(it -> it.getItemId() == item.getId())) {
 				player.getCollectionLog().handleDrop(player, rewardLevel.ordinal(), item.getId(), item.getAmount());

--- a/src/io/xeros/model/entity/player/packets/itemoptions/ItemOptionFour.java
+++ b/src/io/xeros/model/entity/player/packets/itemoptions/ItemOptionFour.java
@@ -18,6 +18,7 @@ import io.xeros.model.items.ItemAction;
 import io.xeros.model.multiplayersession.MultiplayerSessionFinalizeType;
 import io.xeros.model.multiplayersession.MultiplayerSessionStage;
 import io.xeros.model.multiplayersession.MultiplayerSessionType;
+import io.xeros.content.trails.ClueCasketHandler;
 import io.xeros.model.multiplayersession.duel.DuelSession;
 import io.xeros.util.Misc;
 
@@ -74,14 +75,17 @@ public class ItemOptionFour implements PacketType {
 		}
 		TeleportTablets.operate(c, itemId);
 		DuelSession duelSession = (DuelSession) Server.getMultiplayerSessionListener().getMultiplayerSession(c, MultiplayerSessionType.DUEL);
-		if (Objects.nonNull(duelSession) && duelSession.getStage().getStage() > MultiplayerSessionStage.REQUEST
-				&& duelSession.getStage().getStage() < MultiplayerSessionStage.FURTHER_INTERATION) {
-			c.sendMessage("Your actions have declined the duel.");
-			duelSession.getOther(c).sendMessage("The challenger has declined the duel.");
-			duelSession.finish(MultiplayerSessionFinalizeType.WITHDRAW_ITEMS);
-			return;
-		}
-		Optional<DegradableItem> d = DegradableItem.forId(itemId);
+                if (Objects.nonNull(duelSession) && duelSession.getStage().getStage() > MultiplayerSessionStage.REQUEST
+                                && duelSession.getStage().getStage() < MultiplayerSessionStage.FURTHER_INTERATION) {
+                        c.sendMessage("Your actions have declined the duel.");
+                        duelSession.getOther(c).sendMessage("The challenger has declined the duel.");
+                        duelSession.finish(MultiplayerSessionFinalizeType.WITHDRAW_ITEMS);
+                        return;
+                }
+                if (ClueCasketHandler.bulkOpenCasket(c, itemId, c.getItems().getItemAmount(itemId))) {
+                        return;
+                }
+                Optional<DegradableItem> d = DegradableItem.forId(itemId);
 		if (d.isPresent()) {
 			Degrade.checkPercentage(c, itemId);
 			return;

--- a/src/io/xeros/model/entity/player/packets/itemoptions/ItemOptionThree.java
+++ b/src/io/xeros/model/entity/player/packets/itemoptions/ItemOptionThree.java
@@ -19,6 +19,7 @@ import io.xeros.model.Items;
 import io.xeros.model.definitions.ItemDef;
 import io.xeros.model.entity.player.PacketType;
 import io.xeros.model.entity.player.Player;
+import io.xeros.content.trails.ClueCasketHandler;
 import io.xeros.model.entity.player.Right;
 import io.xeros.model.items.GameItem;
 import io.xeros.model.items.ItemAction;
@@ -90,6 +91,9 @@ public class ItemOptionThree implements PacketType {
             c.sendMessage("Your actions have declined the duel.");
             duelSession.getOther(c).sendMessage("The challenger has declined the duel.");
             duelSession.finish(MultiplayerSessionFinalizeType.WITHDRAW_ITEMS);
+            return;
+        }
+        if (ClueCasketHandler.bulkOpenCasket(c, itemId, 10)) {
             return;
         }
         Optional<DegradableItem> d = DegradableItem.forId(itemId);

--- a/src/io/xeros/model/entity/player/packets/itemoptions/ItemOptionTwo.java
+++ b/src/io/xeros/model/entity/player/packets/itemoptions/ItemOptionTwo.java
@@ -3,6 +3,7 @@ package io.xeros.model.entity.player.packets.itemoptions;
 import io.xeros.Configuration;
 import io.xeros.Server;
 import io.xeros.content.bosspoints.JarsToPoints;
+import io.xeros.content.trails.ClueCasketHandler;
 import io.xeros.content.combat.Hitmark;
 import io.xeros.content.combat.magic.SanguinestiStaff;
 import io.xeros.content.displayname.ChangeDisplayName;
@@ -88,18 +89,22 @@ public class ItemOptionTwo implements PacketType {
 		if (Halloween.handleBucket(player, itemId)) {
 			return;
 		}
-		DuelSession duelSession = (DuelSession) Server.getMultiplayerSessionListener().getMultiplayerSession(player, MultiplayerSessionType.DUEL);
-		if (Objects.nonNull(duelSession) && duelSession.getStage().getStage() > MultiplayerSessionStage.REQUEST
-				&& duelSession.getStage().getStage() < MultiplayerSessionStage.FURTHER_INTERATION) {
-			player.sendMessage("Your actions have declined the duel.");
-			duelSession.getOther(player).sendMessage("The challenger has declined the duel.");
-			duelSession.finish(MultiplayerSessionFinalizeType.WITHDRAW_ITEMS);
-			return;
-		}
+                DuelSession duelSession = (DuelSession) Server.getMultiplayerSessionListener().getMultiplayerSession(player, MultiplayerSessionType.DUEL);
+                if (Objects.nonNull(duelSession) && duelSession.getStage().getStage() > MultiplayerSessionStage.REQUEST
+                                && duelSession.getStage().getStage() < MultiplayerSessionStage.FURTHER_INTERATION) {
+                        player.sendMessage("Your actions have declined the duel.");
+                        duelSession.getOther(player).sendMessage("The challenger has declined the duel.");
+                        duelSession.finish(MultiplayerSessionFinalizeType.WITHDRAW_ITEMS);
+                        return;
+                }
 
-		if (JarsToPoints.open(player, itemId)) {
-			return;
-		}
+                if (ClueCasketHandler.bulkOpenCasket(player, itemId, 5)) {
+                        return;
+                }
+
+                if (JarsToPoints.open(player, itemId)) {
+                        return;
+                }
 
 		if (BryophytaStaff.handleItemOption(player, itemId, 2))
 			return;


### PR DESCRIPTION
## Summary
- add ClueCasketHandler to simulate opening multiple clue scrolls or caskets and aggregate rewards
- allow item option handlers to trigger bulk opening for 5, 10 or all caskets
- extend TreasureTrails reward generation to optionally suppress rare announcements

## Testing
- `gradle test` *(fails: java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*

------
https://chatgpt.com/codex/tasks/task_e_688ecda63c488320a8134e9a8591dcff