### PR TITLE
Add activity-driven global boss spawns

### DIFF
--- a/src/io/xeros/content/activityboss/ActivityBossData.java
+++ b/src/io/xeros/content/activityboss/ActivityBossData.java
@@ -1,0 +1,70 @@
+package io.xeros.content.activityboss;
+
+import io.xeros.model.entity.player.Position;
+import java.util.Arrays;
+
+/**
+ * Data for bosses that spawn from server wide activities.
+ */
+public enum ActivityBossData {
+    CORRUPTED_HYDRA(9021, "Corrupted Hydra", ActivityType.UPGRADES, 500,
+            new Position(1310, 3615, 0),
+            "The Corrupted Hydra emerges from the toxic swamp!"),
+
+    TREASURE_MIMIC(8633, "Treasure Mimic", ActivityType.CLUES, 250,
+            new Position(3087, 3495, 0),
+            "A Treasure Mimic materialises, guarding its hoard!"),
+
+    ASHEN_BEAST(9022, "Ashen Beast", ActivityType.FIRE_OF_EXCHANGE, 100_000_000,
+            new Position(3039, 3432, 0),
+            "The Ashen Beast rises from the exchange ashes!"),
+
+    BLOOD_REAPER(9023, "Blood Reaper", ActivityType.KILLSTREAK, 1,
+            new Position(3245, 3945, 0),
+            "The Blood Reaper descends upon the Wilderness!");
+
+    private final int npcId;
+    private final String name;
+    private final ActivityType activityType;
+    private final int threshold;
+    private final Position spawnPosition;
+    private final String spawnMessage;
+
+    ActivityBossData(int npcId, String name, ActivityType activityType, int threshold,
+                     Position spawnPosition, String spawnMessage) {
+        this.npcId = npcId;
+        this.name = name;
+        this.activityType = activityType;
+        this.threshold = threshold;
+        this.spawnPosition = spawnPosition;
+        this.spawnMessage = spawnMessage;
+    }
+
+    public int getNpcId() {
+        return npcId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ActivityType getActivityType() {
+        return activityType;
+    }
+
+    public int getThreshold() {
+        return threshold;
+    }
+
+    public Position getSpawnPosition() {
+        return spawnPosition;
+    }
+
+    public String getSpawnMessage() {
+        return spawnMessage;
+    }
+
+    public static ActivityBossData forType(ActivityType type) {
+        return Arrays.stream(values()).filter(it -> it.activityType == type).findFirst().orElse(null);
+    }
+}

--- a/src/io/xeros/content/activityboss/ActivityType.java
+++ b/src/io/xeros/content/activityboss/ActivityType.java
@@ -1,0 +1,15 @@
+package io.xeros.content.activityboss;
+
+/**
+ * Types of tracked activities that can trigger global boss spawns.
+ */
+public enum ActivityType {
+    /** Item upgrades done through the upgrade interface. */
+    UPGRADES,
+    /** Completion of clue scrolls. */
+    CLUES,
+    /** Upgrade points burnt in the Fire of Exchange. */
+    FIRE_OF_EXCHANGE,
+    /** Player achieves a large PvP killstreak. */
+    KILLSTREAK
+}

--- a/src/io/xeros/content/activityboss/GlobalBossActivityManager.java
+++ b/src/io/xeros/content/activityboss/GlobalBossActivityManager.java
@@ -1,0 +1,49 @@
+package io.xeros.content.activityboss;
+
+import io.xeros.model.entity.npc.NPCSpawning;
+import io.xeros.model.entity.player.broadcasts.Broadcast;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Tracks server wide player activity to spawn global bosses when
+ * specific milestones are reached.
+ */
+public class GlobalBossActivityManager {
+
+    /** Total progress for each activity type. */
+    private static final Map<ActivityType, Integer> totals = new EnumMap<>(ActivityType.class);
+
+    private GlobalBossActivityManager() {
+    }
+
+    /**
+     * Records activity and spawns the corresponding boss if the
+     * threshold is met.
+     *
+     * @param type   type of activity
+     * @param amount amount to add toward the threshold
+     */
+    public static synchronized void record(ActivityType type, int amount) {
+        ActivityBossData data = ActivityBossData.forType(type);
+        if (data == null) {
+            return;
+        }
+        int newTotal = totals.getOrDefault(type, 0) + amount;
+        if (newTotal >= data.getThreshold()) {
+            totals.put(type, 0);
+            spawn(data);
+        } else {
+            totals.put(type, newTotal);
+        }
+    }
+
+    private static void spawn(ActivityBossData data) {
+        NPCSpawning.spawnNpc(data.getNpcId(), data.getSpawnPosition().getX(),
+                data.getSpawnPosition().getY(), data.getSpawnPosition().getHeight(), 1, 0);
+        new Broadcast(data.getSpawnMessage())
+                .addTeleport(data.getSpawnPosition())
+                .copyMessageToChatbox()
+                .submit();
+    }
+}

--- a/src/io/xeros/content/combat/pvp/Killstreak.java
+++ b/src/io/xeros/content/combat/pvp/Killstreak.java
@@ -5,7 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import io.xeros.Server;
+import io.xeros.content.activityboss.ActivityType;
+import io.xeros.content.activityboss.GlobalBossActivityManager;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.mode.Mode;
 import io.xeros.model.entity.player.mode.ModeType;
@@ -58,11 +59,14 @@ public class Killstreak {
 	 * 
 	 * @param type the type of killstreak
 	 */
-	public void increase(Type type) {
-		int value = 1 + killstreaks.getOrDefault(type, 0);
-		killstreaks.put(type, value);
-		reward(type);
-	}
+        public void increase(Type type) {
+                int value = 1 + killstreaks.getOrDefault(type, 0);
+                killstreaks.put(type, value);
+                if (value >= 10) {
+                        GlobalBossActivityManager.record(ActivityType.KILLSTREAK, 1);
+                }
+                reward(type);
+        }
 
 	/**
 	 * Rewards the player with some item, points, and or some other form of currency.

--- a/src/io/xeros/content/fireofexchange/FireOfExchange.java
+++ b/src/io/xeros/content/fireofexchange/FireOfExchange.java
@@ -7,6 +7,8 @@ import io.xeros.content.achievement.Achievements;
 import io.xeros.content.event.eventcalendar.EventChallenge;
 import io.xeros.content.leaderboards.LeaderboardType;
 import io.xeros.content.leaderboards.LeaderboardUtils;
+import io.xeros.content.activityboss.ActivityType;
+import io.xeros.content.activityboss.GlobalBossActivityManager;
 import io.xeros.content.prestige.PrestigePerks;
 import io.xeros.content.skills.Skill;
 import io.xeros.content.upgrade.UpgradeMaterials;
@@ -177,6 +179,7 @@ public class FireOfExchange {
         }
         c.getRecentlyDissolvedItems().add(c.currentExchangeItem);
         c.getRecentlyDissolvedPrices().add(exchangePrice);
+        GlobalBossActivityManager.record(ActivityType.FIRE_OF_EXCHANGE, (int) exchangePrice);
         Server.getLogging().write(new FireOfExchangeLog(c, new GameItem(c.currentExchangeItem, c.currentExchangeItemAmount)));
     }
 

--- a/src/io/xeros/content/trails/TreasureTrails.java
+++ b/src/io/xeros/content/trails/TreasureTrails.java
@@ -6,6 +6,8 @@ import java.util.List;
 import io.xeros.Server;
 import io.xeros.content.achievement.AchievementType;
 import io.xeros.content.achievement.Achievements;
+import io.xeros.content.activityboss.ActivityType;
+import io.xeros.content.activityboss.GlobalBossActivityManager;
 import io.xeros.content.perky.Perks;
 import io.xeros.content.skills.hunter.impling.ItemRarity;
 import io.xeros.model.Items;
@@ -154,26 +156,27 @@ public class TreasureTrails {
 			player.getItems().addItemUnderAnyCircumstance(rewardLevel.getCasketId(),1);
 		}
 
-		switch (rewardLevel) {
-			case EASY:
-				player.setEasyClueCounter(player.getEasyClueCounter() + 1);
-				player.sendMessage("<col=2d256d>You have completed " + player.getEasyClueCounter() + " Easy Treasure Trails.");
-				break;
-			case MEDIUM:
-				player.setMediumClueCounter(player.getMediumClueCounter() + 1);
-				player.sendMessage("<col=2d256d>You have completed " + player.getMediumClueCounter() + " medium Treasure Trails.");
-				break;
-			case HARD:
-				player.setHardClueCounter(player.getHardClueCounter() + 1);
-				player.sendMessage("<col=2d256d>You have completed " + player.getHardClueCounter() + " hard Treasure Trails.");
-				break;
-			case MASTER:
-				player.setMasterClueCounter(player.getMasterClueCounter() + 1);
-				player.sendMessage("<col=2d256d>You have completed " + player.getMasterClueCounter() + " master Treasure Trails.");
-				PetHandler.roll(player, PetHandler.Pets.BLOODHOUND);
-				break;
-		}
-	}
+                switch (rewardLevel) {
+                        case EASY:
+                                player.setEasyClueCounter(player.getEasyClueCounter() + 1);
+                                player.sendMessage("<col=2d256d>You have completed " + player.getEasyClueCounter() + " Easy Treasure Trails.");
+                                break;
+                        case MEDIUM:
+                                player.setMediumClueCounter(player.getMediumClueCounter() + 1);
+                                player.sendMessage("<col=2d256d>You have completed " + player.getMediumClueCounter() + " medium Treasure Trails.");
+                                break;
+                        case HARD:
+                                player.setHardClueCounter(player.getHardClueCounter() + 1);
+                                player.sendMessage("<col=2d256d>You have completed " + player.getHardClueCounter() + " hard Treasure Trails.");
+                                break;
+                        case MASTER:
+                                player.setMasterClueCounter(player.getMasterClueCounter() + 1);
+                                player.sendMessage("<col=2d256d>You have completed " + player.getMasterClueCounter() + " master Treasure Trails.");
+                                PetHandler.roll(player, PetHandler.Pets.BLOODHOUND);
+                                break;
+                }
+                GlobalBossActivityManager.record(ActivityType.CLUES, 1);
+        }
 
 	private static void openClueScroll(Player c, RewardLevel rewardLevel) {
 		if (rewardLevel == RewardLevel.MASTER && !MasterClue.checkRequirementOnOpen(c)) {

--- a/src/io/xeros/content/upgrade/UpgradeInterface.java
+++ b/src/io/xeros/content/upgrade/UpgradeInterface.java
@@ -2,6 +2,8 @@ package io.xeros.content.upgrade;
 
 import io.xeros.content.achievement.AchievementType;
 import io.xeros.content.achievement.Achievements;
+import io.xeros.content.activityboss.ActivityType;
+import io.xeros.content.activityboss.GlobalBossActivityManager;
 import io.xeros.content.prestige.PrestigePerks;
 import io.xeros.content.skills.Skill;
 import io.xeros.model.definitions.ItemDef;
@@ -184,6 +186,7 @@ public class UpgradeInterface {
                                 if (success) {
                                     player.sendMessage("You successfully upgraded your item!");
                                     Achievements.increase(player, AchievementType.UPGRADE, 1);
+                                    GlobalBossActivityManager.record(ActivityType.UPGRADES, 1);
                                     player.getInventory().addToInventory(new ImmutableItem(val.getReward()));
                                     if (val.isRare()) {
                                             String msg = "@blu@<img=18>[UPGRADE]<img=18>@red@ " + player.getDisplayName()


### PR DESCRIPTION
## Summary
- add `ActivityType` and `ActivityBossData` enums for activity-driven boss spawns
- implement `GlobalBossActivityManager` that tracks server-wide progress and spawns bosses
- hook upgrades, clue completions, Fire of Exchange burns and 10-killstreaks into the activity manager

## Testing
- `gradle test` *(fails: java.lang.NoSuchFieldError: JCTree$JCImport does not have member field 'qualid')*


------
https://chatgpt.com/codex/tasks/task_e_688ecdb28fd083208f282de54f19f7db