### PR TITLE
Add Scroll Converter NPC for donation scroll conversions

### DIFF
--- a/src/io/xeros/content/dialogue/impl/ScrollConverterDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/ScrollConverterDialogue.java
@@ -1,0 +1,39 @@
+package io.xeros.content.dialogue.impl;
+
+import io.xeros.content.dialogue.DialogueBuilder;
+import io.xeros.content.dialogue.DialogueOption;
+import io.xeros.model.Npcs;
+import io.xeros.model.entity.player.Player;
+
+/**
+ * Dialogue for exchanging multiple $5 donation scrolls into higher value scrolls.
+ */
+public class ScrollConverterDialogue extends DialogueBuilder {
+
+    private static final int FIVE_SCROLL = ClaimDonatorScrollDialogue.DonationScroll.FIVE.getItemId();
+
+    public ScrollConverterDialogue(Player player) {
+        super(player);
+        setNpcId(Npcs.SCROLL_CONVERTER);
+        npc("Hello! Want to consolidate your scrolls?");
+        option(
+                new DialogueOption("Convert $5 into $10", p -> convert(p, 2, ClaimDonatorScrollDialogue.DonationScroll.TEN)),
+                new DialogueOption("Convert $5 into $25", p -> convert(p, 5, ClaimDonatorScrollDialogue.DonationScroll.TWENTY_FIVE)),
+                new DialogueOption("Convert $5 into $50", p -> convert(p, 10, ClaimDonatorScrollDialogue.DonationScroll.FIFTY)),
+                new DialogueOption("Convert $5 into $100", p -> convert(p, 20, ClaimDonatorScrollDialogue.DonationScroll.ONE_HUNDRED)),
+                new DialogueOption("Nevermind", p -> p.getPA().closeAllWindows())
+        );
+    }
+
+    private void convert(Player player, int required, ClaimDonatorScrollDialogue.DonationScroll result) {
+        if (player.getItems().getInventoryCount(FIVE_SCROLL) < required) {
+            player.sendMessage("You need " + required + " $5 scrolls to do that.");
+            player.getPA().closeAllWindows();
+            return;
+        }
+        player.getItems().deleteItem2(FIVE_SCROLL, required);
+        player.getItems().addItem(result.getItemId(), 1);
+        player.sendMessage("Converted " + required + "x $5 scrolls into a $" + result.getDonationAmount() + " scroll.");
+        player.getPA().closeAllWindows();
+    }
+}

--- a/src/io/xeros/model/Npcs.java
+++ b/src/io/xeros/model/Npcs.java
@@ -7936,6 +7936,7 @@ public class Npcs {
     public static final int LADY_KELYN_ITHELL = 8_913;
     public static final int KELYN = 8_914;
     public static final int LADY_KELYN_ITHELL_2 = 8_915;
+    public static final int SCROLL_CONVERTER = 8_916;
     public static final int FRAGMENT_OF_SEREN = 8_917;
     public static final int FRAGMENT_OF_SEREN_2 = 8_918;
     public static final int FRAGMENT_OF_SEREN_3 = 8_919;

--- a/src/io/xeros/model/entity/player/packets/npcoptions/NpcOptionOne.java
+++ b/src/io/xeros/model/entity/player/packets/npcoptions/NpcOptionOne.java
@@ -15,6 +15,7 @@ import io.xeros.content.dialogue.impl.IronmanNpcDialogue;
 import io.xeros.content.dialogue.impl.MacDialogue;
 import io.xeros.content.dialogue.impl.MonkChaosAltarDialogue;
 import io.xeros.content.dialogue.impl.PineAwayDialogue;
+import io.xeros.content.dialogue.impl.ScrollConverterDialogue;
 import io.xeros.content.minigames.inferno.Inferno;
 import io.xeros.content.minigames.tob.TobConstants;
 import io.xeros.content.miniquests.magearenaii.dialogue.KolodionDialogue;
@@ -113,14 +114,17 @@ public class NpcOptionOne {
 					player.start(new DialogueBuilder(player).npc(4249, "You don't have anytime left on the island!"));
 				}
 				break;
-		case Npcs.JAMES:
-			player.start(new PineAwayDialogue(player, npc));
-			break;
-		case FarmingTeleport.NPC:
-			player.start(new FarmingTeleport(player, npc));
-			break;
-		case DailyRewardsDialogue.DAILY_REWARDS_NPC:
-			int totalReq = (player.getMode().is5x() ? 100 : 500);
+                case Npcs.JAMES:
+                        player.start(new PineAwayDialogue(player, npc));
+                        break;
+                case Npcs.SCROLL_CONVERTER:
+                        player.start(new ScrollConverterDialogue(player));
+                        break;
+                case FarmingTeleport.NPC:
+                        player.start(new FarmingTeleport(player, npc));
+                        break;
+                case DailyRewardsDialogue.DAILY_REWARDS_NPC:
+                        int totalReq = (player.getMode().is5x() ? 100 : 500);
 			if (player.totalLevel >= totalReq) {
 				player.start(new DailyRewardsDialogue(player));
 			} else {


### PR DESCRIPTION
## Summary
- introduce Scroll Converter dialogue to exchange multiple $5 donation scrolls into $10, $25, $50, and $100 scrolls
- register Scroll Converter NPC id and wire it into the NPC interaction handling

## Testing
- `gradle test` *(fails: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*


------
https://chatgpt.com/codex/tasks/task_e_688ecfbe31c48320abe4029ecc9f0886