### PR TITLE
Handle CoX chest rewards with bank overflow

### DIFF
--- a/src/io/xeros/content/item/lootable/impl/RaidsChestCommon.java
+++ b/src/io/xeros/content/item/lootable/impl/RaidsChestCommon.java
@@ -51,22 +51,34 @@ public class RaidsChestCommon implements Lootable {
     public void roll(Player c) {
         int twistedhornsroll = Misc.random(120);
         if (twistedhornsroll == 1) {
-            c.getItems().addItem(24466, 1);
-            PlayerHandler.executeGlobalMessage("@bla@[@blu@RAIDS@bla@] "+ c.getDisplayName() +"@pur@ has just received twisted horns.");
+            giveReward(c, new GameItem(24466, 1), false);
+            PlayerHandler.executeGlobalMessage("@bla@[@blu@RAIDS@bla@] " + c.getDisplayName() + "@pur@ has just received twisted horns.");
         }
         if (c.getItems().playerHasItem(KEY)) {
             c.getItems().deleteItem(KEY, 1);
             c.startAnimation(ANIMATION);
-            GameItem reward =  randomChestRewards();
+            GameItem reward = randomChestRewards();
             GameItem reward2 = randomChestRewards();
             GameItem reward3 = randomChestRewards();
 
-            c.getItems().addItem(reward.getId(),  (PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10) ?reward.getAmount() * 2:reward.getAmount())); //potentially gives the loot 3 times.
-            c.getItems().addItem(reward2.getId(), (PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10) ?reward2.getAmount() * 2:reward2.getAmount())); //potentially gives the loot 3 times.
-            c.getItems().addItem(reward3.getId(), (PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10) ?reward3.getAmount()* 2:reward3.getAmount())); //potentially gives the loot 3 times.
+            giveReward(c, reward, true);
+            giveReward(c, reward2, true);
+            giveReward(c, reward3, true);
             c.sendMessage("@blu@You received a common item out of the storage unit.");
         } else {
             c.sendMessage("@blu@The chest is locked, it won't budge!");
+        }
+    }
+
+    private void giveReward(Player c, GameItem reward, boolean allowDouble) {
+        int amount = reward.getAmount();
+        if (allowDouble && PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10)) {
+            amount *= 2;
+        }
+        if (c.getItems().addItem(reward.getId(), amount)) {
+            c.sendMessage("You receive " + reward.getDef().getName() + " x" + amount + ".");
+        } else {
+            c.getItems().addItemToBankOrDrop(reward.getId(), amount);
         }
     }
 }

--- a/src/io/xeros/content/item/lootable/impl/RaidsChestPlus.java
+++ b/src/io/xeros/content/item/lootable/impl/RaidsChestPlus.java
@@ -59,11 +59,23 @@ public class RaidsChestPlus implements Lootable {
             } else if (reward.getId() == 20997) {
                 c.getCollectionLog().handleDrop(c, 7554, reward.getId(), reward.getAmount());
             }
-            c.getItems().addItem(reward.getId(), (PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10) ? reward.getAmount() * 2 : reward.getAmount()));
+            giveReward(c, reward);
             c.sendMessage("@blu@You have received a rare item out of the storage unit.");
             NPCDeath.announceKc(c, reward, "Raids chest", c.raidCount);
         } else {
             c.sendMessage("@blu@The chest is locked, it won't budge!");
+        }
+    }
+
+    private void giveReward(Player c, GameItem reward) {
+        int amount = reward.getAmount();
+        if (PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10)) {
+            amount *= 2;
+        }
+        if (c.getItems().addItem(reward.getId(), amount)) {
+            c.sendMessage("You receive " + reward.getDef().getName() + " x" + amount + ".");
+        } else {
+            c.getItems().addItemToBankOrDrop(reward.getId(), amount);
         }
     }
 

--- a/src/io/xeros/content/item/lootable/impl/RaidsChestRare.java
+++ b/src/io/xeros/content/item/lootable/impl/RaidsChestRare.java
@@ -84,19 +84,31 @@ public class RaidsChestRare implements Lootable {
         if (c.getItems().playerHasItem(KEY)) {
             c.getItems().deleteItem(KEY, 1);
             c.startAnimation(ANIMATION);
-            GameItem reward =  randomChestRewards();
+            GameItem reward = randomChestRewards();
 
             c.getCollectionLog().handleDrop(c, 7554, reward.getId(), reward.getAmount());
             if (reward.getId() == 20851 && c.getItems().getItemCount(20851, false) == 0) {
                 c.getCollectionLog().handleDrop(c, 5, 20851, 1);
             }
-            c.getItems().addItem(reward.getId(), (PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10) ? reward.getAmount() * 2 : reward.getAmount())); //potentially gives the loot 3 times.
+            giveReward(c, reward);
             c.sendMessage("@blu@You have received a rare item out of the storage unit.");
             if (reward.getId() == 20997 || reward.getId() == 20851) {
                 NPCDeath.announceKc(c, reward, "Raids chest", c.raidCount);
             }
         } else {
             c.sendMessage("@blu@The chest is locked, it won't budge!");
+        }
+    }
+
+    private void giveReward(Player c, GameItem reward) {
+        int amount = reward.getAmount();
+        if (PrestigePerks.hasRelic(c, PrestigePerks.DOUBLE_PC_POINTS) && Misc.isLucky(10)) {
+            amount *= 2;
+        }
+        if (c.getItems().addItem(reward.getId(), amount)) {
+            c.sendMessage("You receive " + reward.getDef().getName() + " x" + amount + ".");
+        } else {
+            c.getItems().addItemToBankOrDrop(reward.getId(), amount);
         }
     }
 }

--- a/src/io/xeros/model/entity/player/packets/objectoptions/ObjectOptionOne.java
+++ b/src/io/xeros/model/entity/player/packets/objectoptions/ObjectOptionOne.java
@@ -760,37 +760,37 @@ public class ObjectOptionOne {
                 }
                 c.sendMessage("@red@You need a hammer, Hydra Leather, 15 million coins to do this.");
                 break;
-			case 30107:
-				if (c.getItems().freeSlots() < 3) {
-					c.getDH().sendStatement("@red@You need at least 3 free slots for safety");
-					return;
-				}
-				if (c.getItems().playerHasItem(Raids.COMMON_KEY, 1)) {
-					new RaidsChestCommon().roll(c);
-					return;
-				}
-				if (c.getItems().playerHasItem(Raids.RARE_KEY, 1)) {
-					new RaidsChestRare().roll(c);
-					return;
-				}
-				if (c.getItems().playerHasItem(3468, 1)) {
-					if (Misc.random(100) < 25) {
-						c.getItems().deleteItem2(3468,1);
-						c.getItems().addItem(Raids.RARE_KEY, 1);
-						new RaidsChestPlus().roll(c);
-					} else {
-						c.getItems().deleteItem2(3468,1);
-						c.getItems().addItem(Raids.COMMON_KEY, 1);
-						new RaidsChestCommon().roll(c);
-					}
-					return;
-				}
-				if (c.getItems().playerHasItem(25432, 1)) {
-					new RaidsChestPlus().roll(c);
-					return;
-				}
-				c.getDH().sendStatement("@red@You need either a rare or common key.");
-				break;
+                        case 30107:
+                                if (c.getItems().freeSlots() < 1) {
+                                        c.getDH().sendStatement("@red@You need at least 1 free slot to open this.");
+                                        return;
+                                }
+                                if (c.getItems().playerHasItem(Raids.COMMON_KEY, 1)) {
+                                        new RaidsChestCommon().roll(c);
+                                        return;
+                                }
+                                if (c.getItems().playerHasItem(Raids.RARE_KEY, 1)) {
+                                        new RaidsChestRare().roll(c);
+                                        return;
+                                }
+                                if (c.getItems().playerHasItem(3468, 1)) {
+                                        if (Misc.random(100) < 25) {
+                                                c.getItems().deleteItem2(3468,1);
+                                                c.getItems().addItem(Raids.RARE_KEY, 1);
+                                                new RaidsChestPlus().roll(c);
+                                        } else {
+                                                c.getItems().deleteItem2(3468,1);
+                                                c.getItems().addItem(Raids.COMMON_KEY, 1);
+                                                new RaidsChestCommon().roll(c);
+                                        }
+                                        return;
+                                }
+                                if (c.getItems().playerHasItem(25432, 1)) {
+                                        new RaidsChestPlus().roll(c);
+                                        return;
+                                }
+                                c.getDH().sendStatement("@red@You need either a rare or common key.");
+                                break;
             case 32508:
                 c.objectDistance = 13;
 /*				if (!(System.currentTimeMillis() - c.chestDelay > 2000)) {


### PR DESCRIPTION
## Summary
- Allow CoX storage chest to be opened with just one free inventory slot
- Route each CoX chest reward to inventory or bank with a per-item message
- Apply overflow handling across common, rare, and plus CoX chests

## Testing
- `gradle test` *(fails: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*

------
https://chatgpt.com/codex/tasks/task_e_688ecf97e8c083208b3c02c9c18d684e