### PR TITLE
Add map load auditing and fallback

### DIFF
--- a/src/io/xeros/content/instances/InstancedArea.java
+++ b/src/io/xeros/content/instances/InstancedArea.java
@@ -6,6 +6,7 @@ import io.xeros.content.combat.Hitmark;
 import io.xeros.model.collisionmap.Region;
 import io.xeros.model.collisionmap.RegionProvider;
 import io.xeros.model.collisionmap.WorldObject;
+import io.xeros.model.collisionmap.MapLoadLogger;
 import io.xeros.model.entity.Entity;
 import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.player.Boundary;
@@ -126,12 +127,21 @@ public abstract class InstancedArea extends RegionProvider {
 
     @Override
     public Region get(int x, int y) {
-        if (contains(x, y)) {
+        int regionId = getHash(x, y);
+        boolean alreadyLoaded = contains(x, y);
+        if (alreadyLoaded) {
+            MapLoadLogger.log("InstancedArea.get", regionId, "dynamic", true, true, null);
             return super.get(x, y);
         } else {
-            Region region = RegionProvider.getGlobal().get(x, y).clone(this);
-            add(region);
-            return region;
+            try {
+                Region region = RegionProvider.getGlobal().get(x, y).clone(this);
+                add(region);
+                MapLoadLogger.log("InstancedArea.get", regionId, "dynamic", false, true, null);
+                return region;
+            } catch (Exception e) {
+                MapLoadLogger.log("InstancedArea.get", regionId, "dynamic", false, false, e);
+                return RegionProvider.getGlobal().get(x, y);
+            }
         }
     }
 

--- a/src/io/xeros/model/collisionmap/MapLoadLogger.java
+++ b/src/io/xeros/model/collisionmap/MapLoadLogger.java
@@ -1,0 +1,23 @@
+package io.xeros.model.collisionmap;
+
+import java.util.logging.Logger;
+
+/**
+ * Utility for auditing map and region loading.
+ */
+public final class MapLoadLogger {
+
+    private static final Logger logger = Logger.getLogger(MapLoadLogger.class.getName());
+
+    private MapLoadLogger() {
+    }
+
+    public static void log(String source, int regionId, String mapFile, boolean alreadyLoaded, boolean success, Throwable t) {
+        String message = String.format("[MapLoad] source=%s regionId=%d file=%s alreadyLoaded=%s success=%s", source, regionId, mapFile, alreadyLoaded, success);
+        if (t != null) {
+            logger.warning(message + " error=" + t.getMessage());
+        } else {
+            logger.info(message);
+        }
+    }
+}

--- a/src/io/xeros/model/collisionmap/Region.java
+++ b/src/io/xeros/model/collisionmap/Region.java
@@ -537,6 +537,7 @@ public class Region {
     public static void load() {
         try {
             System.out.println("Loading mapdata..");
+            MapLoadLogger.log("Region.load", -1, "map_index", false, true, null);
             File f = new File("./mapdata/map_index");
             byte[] buffer = new byte[(int) f.length()];
             DataInputStream dis = new DataInputStream(new FileInputStream(f));
@@ -548,6 +549,7 @@ public class Region {
             int[] mapGroundFileIds = new int[size];
             int[] mapObjectsFileIds = new int[size];
             RegionData[] data = new RegionData[size];
+            regions.clear();
             for (int i = 0; i < size; i++) {
                 regionIds[i] = in.readUnsignedWord();
                 mapGroundFileIds[i] = in.readUnsignedWord();
@@ -557,7 +559,9 @@ public class Region {
             for (int i = 0; i < size; i++) {
                 RegionProvider.getGlobal().add(new Region(RegionProvider.getGlobal(), regionIds[i], false));
             }
-            Arrays.stream(data).forEach(Region::loadMap);
+            for (RegionData regionData : data) {
+                loadMap(regionData);
+            }
             Arrays.asList(EXISTANT_OBJECTS).forEach(object -> RegionProvider.getGlobal().get(object.getX(), object.getY()).addWorldObject(object));
             log.info("Loaded " + customMapFiles + " custom maps.");
             log.info("Error loading map files: " + errors.toString());
@@ -655,20 +659,28 @@ public class Region {
         return null;
     }
 
-    private static void loadMap(RegionData regionData) {
+    private static boolean loadMap(RegionData regionData) {
+        int regionId = regionData.getRegionHash();
+        String mapFile = regionData.getObjects() + "," + regionData.getLandscape();
+        boolean alreadyLoaded = regions.containsKey(regionId);
         try {
             byte[] file1 = getBuffer(new File("./mapdata/index4/" + regionData.getObjects() + ".gz"));
             byte[] file2 = getBuffer(new File("./mapdata/index4/" + regionData.getLandscape() + ".gz"));
-            if (file1 == null || file2 == null) {
-                return;
+            if (file1 == null || file1.length == 0 || file2 == null || file2.length == 0) {
+                System.err.println("[Map] Missing or corrupt map for regionId=" + regionId);
+                MapLoadLogger.log("Region.loadMap", regionId, mapFile, alreadyLoaded, false, null);
+                return false;
             }
-            loadMaps(regionData.getRegionHash(), new ByteStream(file1), new ByteStream(file2));
+            loadMaps(regionId, new ByteStream(file1), new ByteStream(file2));
+            MapLoadLogger.log("Region.loadMap", regionId, mapFile, alreadyLoaded, true, null);
+            regions.put(regionId, regionData);
+            return true;
         } catch (Exception e) {
             errors.add(regionData.getLandscape());
             errors.add(regionData.getObjects());
+            MapLoadLogger.log("Region.loadMap", regionId, mapFile, alreadyLoaded, false, e);
+            return false;
         }
-        //System.out.println("Error loading map region: " + regionData.getRegionHash() + ", objectFile: " + regionData.getObjects() + ", floorFile: " + regionData.getLandscape());
-        //e.printStackTrace();
     }
 
     private static final int[][] fixClips = {{2207, 3057},


### PR DESCRIPTION
## Summary
- introduce `MapLoadLogger` to audit region/map loading
- log region loads and add fallback when map data is missing or corrupt
- trace dynamic region creation within `InstancedArea`

## Testing
- `gradle test` *(fails: <identifier> expected in BossInstanceManager)*

------
https://chatgpt.com/codex/tasks/task_e_688ee2368fc08320b7c57302d19b3985