### PR TITLE
fix: sanitize boss instance dialogue labels

### DIFF
--- a/src/io/xeros/content/commands/test/TestZonesClean.java
+++ b/src/io/xeros/content/commands/test/TestZonesClean.java
@@ -1,0 +1,36 @@
+package io.xeros.content.commands.test;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.model.entity.player.Player;
+import io.xeros.util.Misc;
+
+/**
+ * Debug command that prints the sanitised boss tier zone names to verify
+ * none of them contain characters that render invisibly in dialogue.
+ */
+public class TestZonesClean extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        for (BossTier tier : BossTier.values()) {
+            String zone = tier.getZoneName();
+            if (zone == null) {
+                zone = "null";
+            }
+            String cleanZone = zone.replaceAll("[^\\p{ASCII}]", "").replaceAll("[–—•]", "-");
+            player.sendMessage("Tier " + (tier.ordinal() + 1) + ": " + cleanZone);
+            Misc.println("testzones_clean tier=" + tier + " zone=" + cleanZone);
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return true; // accessible in test environments
+    }
+
+    @Override
+    public String getCommand() {
+        return "testzones_clean";
+    }
+}

--- a/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
@@ -29,6 +29,9 @@ public class BossInstanceDialogue extends DialogueBuilder {
     /** Maximum number of options shown per page. */
     private static final int OPTIONS_PER_PAGE = 5;
 
+    /** Maximum length of an option label before it is truncated. */
+    private static final int MAX_OPTION_LENGTH = 50;
+
     /** Current page being viewed. */
     private final int page;
 
@@ -71,7 +74,6 @@ public class BossInstanceDialogue extends DialogueBuilder {
             BossTier tier = tiers[startIndex + i];
             displayed.add(tier);
             String label = buildTierLabel(player, tier);
-            Misc.println("BossInstanceDialogue option " + (startIndex + i) + ": " + label);
             final int slot = opts.size();
             opts.add(new DialogueOption(label, p -> run(0, slot)));
         }
@@ -92,12 +94,26 @@ public class BossInstanceDialogue extends DialogueBuilder {
 
     /**
      * Builds a safe, colour-coded label for a tier showing progress and key drops.
+     * <p>
+     * The resulting string is logged and truncated if it exceeds {@link #MAX_OPTION_LENGTH}
+     * to prevent invisible dialogue options.
+     * </p>
      */
     private String buildTierLabel(Player player, BossTier tier) {
         if (tier == null) {
             Misc.println("BossInstanceDialogue warning: null tier label");
             return "@red@Unavailable";
         }
+
+        String zone = tier.getZoneName();
+        if (zone == null || zone.trim().isEmpty()) {
+            zone = "Unknown Zone";
+            Misc.println("BossInstanceDialogue warning: missing zone name for " + tier);
+        }
+
+        // Sanitize the zone to avoid invisible or client-breaking characters.
+        zone = zone.replaceAll("[^\\p{ASCII}]", "");
+        zone = zone.replaceAll("[–—•]", "-");
 
         StringBuilder label = new StringBuilder(BossInstanceManager.getTierDisplayNameSafe(tier, player));
 
@@ -116,7 +132,19 @@ public class BossInstanceDialogue extends DialogueBuilder {
             }
         }
 
-        return label.toString();
+        String result = label.toString();
+
+        // Strip any remaining non-ASCII characters after building the label.
+        result = result.replaceAll("[^\\p{ASCII}]", "");
+        result = result.replaceAll("[–—•]", "-");
+
+        if (result.length() > MAX_OPTION_LENGTH) {
+            Misc.println("BossInstanceDialogue truncating label for " + tier + " from " + result.length() + " chars: " + result);
+            result = result.substring(0, MAX_OPTION_LENGTH - 3) + "...";
+        }
+
+        Misc.println("BossInstanceDialogue option tier=" + tier + " zone=" + zone + " display=" + result);
+        return result;
     }
 
     /**

--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -304,7 +304,21 @@ public class BossInstanceManager {
             Misc.println("BossInstanceManager warning: missing zone name for " + tier);
             zone = "Unknown";
         }
-        String base = "Tier " + (tier.ordinal() + 1) + " – " + zone;
+
+        // Strip non ASCII characters and normalise special dashes so the
+        // dialogue renders consistently across clients.
+        zone = zone.replaceAll("[^\\p{ASCII}]", "");
+        zone = zone.replaceAll("[–—•]", "-");
+
+        String base = "Tier " + (tier.ordinal() + 1) + " - " + zone;
+
+        // Hard cap the length to avoid invisible options.
+        if (base.length() > 50) {
+            base = base.substring(0, 47) + "...";
+        }
+
+        Misc.println("AOE Dialogue: " + base);
+
         if (player == null) {
             return base;
         }


### PR DESCRIPTION
## Summary
- Strip non-ASCII and special dash characters from boss instance zone names
- Truncate and log sanitized labels to keep dialogue options visible
- Add `::testzones_clean` debug command to preview cleaned zone names

## Testing
- `gradle test` *(fails: NoSuchFieldError: JCTree$JCImport)*

------
https://chatgpt.com/codex/tasks/task_e_689253f24f448320a6b276a71ebdb47c