### PR TITLE
Add Scroll Converter NPC for donation scroll conversions

### DIFF
--- a/src/io/xeros/content/commands/all/ConvertScrolls.java
+++ b/src/io/xeros/content/commands/all/ConvertScrolls.java
@@ -1,0 +1,27 @@
+package io.xeros.content.commands.all;
+
+import io.xeros.Server;
+import io.xeros.content.commands.Command;
+import io.xeros.content.dialogue.impl.ScrollConverterDialogue;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Player;
+
+/**
+ * Shortcut command to open the scroll converter dialogue.
+ */
+public class ConvertScrolls extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        if (Boundary.isIn(player, Boundary.DUEL_ARENA) || Server.getMultiplayerSessionListener().inAnySession(player)) {
+            player.sendMessage("You cannot convert scrolls right now.");
+            return;
+        }
+        player.start(new ScrollConverterDialogue(player));
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return true;
+    }
+}

--- a/src/io/xeros/content/dialogue/impl/ScrollConverterDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/ScrollConverterDialogue.java
@@ -1,0 +1,45 @@
+package io.xeros.content.dialogue.impl;
+
+import io.xeros.content.dialogue.DialogueBuilder;
+import io.xeros.content.dialogue.DialogueOption;
+import io.xeros.content.items.ScrollConversionService;
+import io.xeros.content.dialogue.impl.ClaimDonatorScrollDialogue.DonationScroll;
+import io.xeros.model.Npcs;
+import io.xeros.model.entity.player.Player;
+
+/**
+ * Dialogue for exchanging donation scrolls between denominations.
+ */
+public class ScrollConverterDialogue extends DialogueBuilder {
+
+    public ScrollConverterDialogue(Player player) {
+        super(player);
+        setNpcId(Npcs.SCROLL_CONVERTER);
+        npc("Hello! Want to consolidate your scrolls?");
+        option(
+                new DialogueOption("Convert $5 scrolls", ScrollConverterDialogue::openConvertMenu),
+                new DialogueOption("Reverse convert scrolls", ScrollConverterDialogue::openReverseMenu),
+                new DialogueOption("Nevermind", p -> p.getPA().closeAllWindows())
+        );
+    }
+
+    private static void openConvertMenu(Player player) {
+        player.start(new DialogueBuilder(player).setNpcId(Npcs.SCROLL_CONVERTER).option(
+                new DialogueOption("Convert $5 into $10", p -> ScrollConversionService.convertUp(p, 2, DonationScroll.TEN)),
+                new DialogueOption("Convert $5 into $25", p -> ScrollConversionService.convertUp(p, 5, DonationScroll.TWENTY_FIVE)),
+                new DialogueOption("Convert $5 into $50", p -> ScrollConversionService.convertUp(p, 10, DonationScroll.FIFTY)),
+                new DialogueOption("Convert $5 into $100", p -> ScrollConversionService.convertUp(p, 20, DonationScroll.ONE_HUNDRED)),
+                new DialogueOption("Batch Convert All Scrolls", ScrollConversionService::batchConvert)
+        ));
+    }
+
+    private static void openReverseMenu(Player player) {
+        player.start(new DialogueBuilder(player).setNpcId(Npcs.SCROLL_CONVERTER).option(
+                new DialogueOption("Convert $10 into $5s", p -> ScrollConversionService.convertDown(p, DonationScroll.TEN, 2)),
+                new DialogueOption("Convert $25 into $5s", p -> ScrollConversionService.convertDown(p, DonationScroll.TWENTY_FIVE, 5)),
+                new DialogueOption("Convert $50 into $5s", p -> ScrollConversionService.convertDown(p, DonationScroll.FIFTY, 10)),
+                new DialogueOption("Convert $100 into $5s", p -> ScrollConversionService.convertDown(p, DonationScroll.ONE_HUNDRED, 20)),
+                new DialogueOption("Nevermind", p -> p.getPA().closeAllWindows())
+        ));
+    }
+}

--- a/src/io/xeros/content/items/ScrollConversionLogger.java
+++ b/src/io/xeros/content/items/ScrollConversionLogger.java
@@ -1,0 +1,17 @@
+package io.xeros.content.items;
+
+import io.xeros.model.entity.player.Player;
+
+import java.util.logging.Logger;
+
+/**
+ * Logs scroll conversion events.
+ */
+public class ScrollConversionLogger {
+
+    private static final Logger logger = Logger.getLogger(ScrollConversionLogger.class.getName());
+
+    public static void log(Player player, String message) {
+        logger.info("[" + player.getDisplayName() + "] " + message);
+    }
+}

--- a/src/io/xeros/content/items/ScrollConversionService.java
+++ b/src/io/xeros/content/items/ScrollConversionService.java
@@ -1,0 +1,96 @@
+package io.xeros.content.items;
+
+import io.xeros.content.dialogue.impl.ClaimDonatorScrollDialogue.DonationScroll;
+import io.xeros.model.entity.player.Player;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Handles converting donation scrolls between denominations.
+ */
+public class ScrollConversionService {
+
+    private static final int FIVE_SCROLL = DonationScroll.FIVE.getItemId();
+
+    public static void convertUp(Player player, int required, DonationScroll result) {
+        if (player.getItems().getInventoryCount(FIVE_SCROLL) < required) {
+            player.sendMessage("You need " + required + " $5 scrolls to do that.");
+            player.getPA().closeAllWindows();
+            return;
+        }
+        player.getItems().deleteItem2(FIVE_SCROLL, required);
+        player.getItems().addItem(result.getItemId(), 1);
+        player.sendMessage("Converted " + required + "x $5 scrolls into a $" + result.getDonationAmount() + " scroll.");
+        ScrollConversionLogger.log(player, "Converted " + required + "x $5 into $" + result.getDonationAmount());
+        player.getPA().closeAllWindows();
+    }
+
+    public static void convertDown(Player player, DonationScroll from, int fiveScrolls) {
+        if (!player.getItems().playerHasItem(from.getItemId())) {
+            player.sendMessage("You need a $" + from.getDonationAmount() + " scroll to do that.");
+            player.getPA().closeAllWindows();
+            return;
+        }
+        int requiredSlots = fiveScrolls - 1; // removing one scroll, adding many
+        if (player.getItems().freeSlots() < requiredSlots) {
+            player.sendMessage("You need " + requiredSlots + " free inventory slots to do that.");
+            player.getPA().closeAllWindows();
+            return;
+        }
+        player.getItems().deleteItem2(from.getItemId(), 1);
+        player.getItems().addItem(FIVE_SCROLL, fiveScrolls);
+        player.sendMessage("Converted a $" + from.getDonationAmount() + " scroll into " + fiveScrolls + "x $5 scrolls.");
+        ScrollConversionLogger.log(player, "Converted $" + from.getDonationAmount() + " into " + fiveScrolls + "x $5");
+        player.getPA().closeAllWindows();
+    }
+
+    public static void batchConvert(Player player) {
+        int total = player.getItems().getInventoryCount(FIVE_SCROLL);
+        if (total <= 0) {
+            player.sendMessage("You don't have any $5 scrolls to convert.");
+            player.getPA().closeAllWindows();
+            return;
+        }
+        int remaining = total;
+        Map<DonationScroll, Integer> results = new LinkedHashMap<>();
+
+        int num100 = remaining / 20;
+        if (num100 > 0) {
+            results.put(DonationScroll.ONE_HUNDRED, num100);
+            remaining -= num100 * 20;
+            player.getItems().addItem(DonationScroll.ONE_HUNDRED.getItemId(), num100);
+        }
+        int num50 = remaining / 10;
+        if (num50 > 0) {
+            results.put(DonationScroll.FIFTY, num50);
+            remaining -= num50 * 10;
+            player.getItems().addItem(DonationScroll.FIFTY.getItemId(), num50);
+        }
+        int num25 = remaining / 5;
+        if (num25 > 0) {
+            results.put(DonationScroll.TWENTY_FIVE, num25);
+            remaining -= num25 * 5;
+            player.getItems().addItem(DonationScroll.TWENTY_FIVE.getItemId(), num25);
+        }
+        int num10 = remaining / 2;
+        if (num10 > 0) {
+            results.put(DonationScroll.TEN, num10);
+            remaining -= num10 * 2;
+            player.getItems().addItem(DonationScroll.TEN.getItemId(), num10);
+        }
+        int used = total - remaining;
+        if (used > 0) {
+            player.getItems().deleteItem2(FIVE_SCROLL, used);
+        }
+        player.sendMessage("Converted " + used + " x $5 scrolls into:");
+        for (Map.Entry<DonationScroll, Integer> entry : results.entrySet()) {
+            player.sendMessage("- " + entry.getValue() + " x $" + entry.getKey().getDonationAmount());
+        }
+        if (remaining > 0) {
+            player.sendMessage("- " + remaining + " x $5");
+        }
+        ScrollConversionLogger.log(player, "Batch converted " + used + " of " + total + " $5 scrolls");
+        player.getPA().closeAllWindows();
+    }
+}

--- a/src/io/xeros/model/Npcs.java
+++ b/src/io/xeros/model/Npcs.java
@@ -7936,6 +7936,7 @@ public class Npcs {
     public static final int LADY_KELYN_ITHELL = 8_913;
     public static final int KELYN = 8_914;
     public static final int LADY_KELYN_ITHELL_2 = 8_915;
+    public static final int SCROLL_CONVERTER = 8_916;
     public static final int FRAGMENT_OF_SEREN = 8_917;
     public static final int FRAGMENT_OF_SEREN_2 = 8_918;
     public static final int FRAGMENT_OF_SEREN_3 = 8_919;

--- a/src/io/xeros/model/entity/player/packets/npcoptions/NpcOptionOne.java
+++ b/src/io/xeros/model/entity/player/packets/npcoptions/NpcOptionOne.java
@@ -15,6 +15,7 @@ import io.xeros.content.dialogue.impl.IronmanNpcDialogue;
 import io.xeros.content.dialogue.impl.MacDialogue;
 import io.xeros.content.dialogue.impl.MonkChaosAltarDialogue;
 import io.xeros.content.dialogue.impl.PineAwayDialogue;
+import io.xeros.content.dialogue.impl.ScrollConverterDialogue;
 import io.xeros.content.minigames.inferno.Inferno;
 import io.xeros.content.minigames.tob.TobConstants;
 import io.xeros.content.miniquests.magearenaii.dialogue.KolodionDialogue;
@@ -113,14 +114,17 @@ public class NpcOptionOne {
 					player.start(new DialogueBuilder(player).npc(4249, "You don't have anytime left on the island!"));
 				}
 				break;
-		case Npcs.JAMES:
-			player.start(new PineAwayDialogue(player, npc));
-			break;
-		case FarmingTeleport.NPC:
-			player.start(new FarmingTeleport(player, npc));
-			break;
-		case DailyRewardsDialogue.DAILY_REWARDS_NPC:
-			int totalReq = (player.getMode().is5x() ? 100 : 500);
+                case Npcs.JAMES:
+                        player.start(new PineAwayDialogue(player, npc));
+                        break;
+                case Npcs.SCROLL_CONVERTER:
+                        player.start(new ScrollConverterDialogue(player));
+                        break;
+                case FarmingTeleport.NPC:
+                        player.start(new FarmingTeleport(player, npc));
+                        break;
+                case DailyRewardsDialogue.DAILY_REWARDS_NPC:
+                        int totalReq = (player.getMode().is5x() ? 100 : 500);
 			if (player.totalLevel >= totalReq) {
 				player.start(new DailyRewardsDialogue(player));
 			} else {


### PR DESCRIPTION
## Summary
- expand scroll converter dialogue with menus for $5 upgrades, reverse breakdowns, and a batch convert-all option
- add ScrollConversionService and ScrollConversionLogger to manage and log conversions
- introduce `::convertscrolls` command for quick access outside NPCs, blocked in duels

## Testing
- `gradle test` *(fails: java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*


------
https://chatgpt.com/codex/tasks/task_e_688ecfbe31c48320abe4029ecc9f0886