### PR TITLE
Add fixed AOE arena boundary and spawn logic

### DIFF
--- a/src/io/xeros/content/combat/core/AttackEntity.java
+++ b/src/io/xeros/content/combat/core/AttackEntity.java
@@ -31,6 +31,7 @@ import io.xeros.model.entity.EntityReference;
 import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.npc.NPCClipping;
 import io.xeros.model.entity.npc.NPCHandler;
+import io.xeros.content.instances.BossInstanceManager;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.PlayerHandler;
@@ -339,9 +340,12 @@ public class AttackEntity {
                 }
             }
             //  return;
-        } else if (Boundary.isIn(attacker, Boundary.AOEInstance) && aoeData == null) {
-            attacker.sendMessage("You cannot use this weapon inside the instance!");
-            return;
+        } else {
+            BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(attacker);
+            if (area != null && area.isWithinAoeZone(attacker.getPosition()) && aoeData == null) {
+                attacker.sendMessage("You cannot use this weapon inside the instance!");
+                return;
+            }
         }
 
         if (getCombatType() == CombatType.MAGE && !MagicRequirements.checkMagicReqs(attacker, attacker.getSpellId(),

--- a/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
@@ -117,7 +117,7 @@ public class BossInstanceDialogue extends DialogueBuilder {
         StringBuilder label = new StringBuilder(BossInstanceManager.getTierDisplayNameSafe(tier, player));
 
         // Append up to three key drop names
-        List<GameItem> drops = Server.getDropManager().getNPCdrops(tier.getKillNpcId());
+        List<GameItem> drops = Server.getDropManager().getNPCdrops(tier.getBossNpcId());
         if (drops != null && !drops.isEmpty()) {
             String dropNames = drops.stream()
                     .limit(3)

--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -8,6 +8,7 @@ import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.npc.NPCSpawning;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
 import io.xeros.util.Misc;
 
 import java.util.Arrays;
@@ -45,6 +46,10 @@ public class BossInstanceManager {
         public BossTier getTier() {
             return tier;
         }
+
+        public boolean isWithinAoeZone(Position pos) {
+            return tier.getZoneBoundary().inside(pos);
+        }
     }
 
     /** Description for each mob that can spawn in a tier. */
@@ -53,12 +58,14 @@ public class BossInstanceManager {
         private final int hitpoints;
         private final int attack;
         private final int defence;
+        private final int count;
 
-        public BossMob(int npcId, int hitpoints, int attack, int defence) {
+        public BossMob(int npcId, int hitpoints, int attack, int defence, int count) {
             this.npcId = npcId;
             this.hitpoints = hitpoints;
             this.attack = attack;
             this.defence = defence;
+            this.count = count;
         }
 
         public int getNpcId() {
@@ -76,6 +83,10 @@ public class BossInstanceManager {
         public int getDefence() {
             return defence;
         }
+
+        public int getCount() {
+            return count;
+        }
     }
 
     /**
@@ -83,26 +94,26 @@ public class BossInstanceManager {
      * the NPCs that can spawn.
      */
     public enum BossTier {
-        TIER1("Training Grounds", 0, 0, -1, 5, Npcs.COW,
-                new BossMob[]{new BossMob(Npcs.COW, 10, 1, 1)}),
-        TIER2("Goblin Camp", 25, 10_000, -1, 10, Npcs.GOBLIN,
-                new BossMob[]{new BossMob(Npcs.GOBLIN, 15, 5, 5)}),
-        TIER3("Giants' Den", 75, 100_000, -1, 20, Npcs.HILL_GIANT,
-                new BossMob[]{new BossMob(Npcs.HILL_GIANT, 35, 20, 20)}),
-        TIER4("Moss Cave", 150, 250_000, -1, 25, Npcs.MOSS_GIANT,
-                new BossMob[]{new BossMob(Npcs.MOSS_GIANT, 60, 40, 40)}),
-        TIER5("Fire Pit", 250, 500_000, -1, 30, Npcs.FIRE_GIANT,
-                new BossMob[]{new BossMob(Npcs.FIRE_GIANT, 80, 60, 60)}),
-        TIER6("Green Dragons", 350, 750_000, -1, 35, Npcs.GREEN_DRAGON,
-                new BossMob[]{new BossMob(Npcs.GREEN_DRAGON, 120, 90, 90)}),
-        TIER7("Red Dragons", 500, 1_000_000, -1, 40, Npcs.RED_DRAGON,
-                new BossMob[]{new BossMob(Npcs.RED_DRAGON, 150, 110, 110)}),
-        TIER8("Black Dragons", 650, 2_000_000, -1, 45, Npcs.BLACK_DRAGON,
-                new BossMob[]{new BossMob(Npcs.BLACK_DRAGON, 180, 130, 130)}),
-        TIER9("Demon Domain", 800, 3_000_000, -1, 50, Npcs.BLACK_DEMON,
-                new BossMob[]{new BossMob(Npcs.BLACK_DEMON, 200, 150, 150)}),
-        TIER10("Dragon King", 1_000, 5_000_000, 11286, 60, Npcs.KING_BLACK_DRAGON,
-                new BossMob[]{new BossMob(Npcs.KING_BLACK_DRAGON, 250, 180, 180)});
+        TIER1("Training Grounds", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 0, 0, -1, 5, Npcs.COW,
+                new BossMob[]{new BossMob(Npcs.COW, 10, 1, 1, 5)}),
+        TIER2("Goblin Camp", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 25, 10_000, -1, 10, Npcs.GOBLIN,
+                new BossMob[]{new BossMob(Npcs.GOBLIN, 15, 5, 5, 5)}),
+        TIER3("Giants' Den", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 75, 100_000, -1, 20, Npcs.HILL_GIANT,
+                new BossMob[]{new BossMob(Npcs.HILL_GIANT, 35, 20, 20, 6)}),
+        TIER4("Moss Cave", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 150, 250_000, -1, 25, Npcs.MOSS_GIANT,
+                new BossMob[]{new BossMob(Npcs.MOSS_GIANT, 60, 40, 40, 6)}),
+        TIER5("Fire Pit", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 250, 500_000, -1, 30, Npcs.FIRE_GIANT,
+                new BossMob[]{new BossMob(Npcs.FIRE_GIANT, 80, 60, 60, 7)}),
+        TIER6("Green Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 350, 750_000, -1, 35, Npcs.GREEN_DRAGON,
+                new BossMob[]{new BossMob(Npcs.GREEN_DRAGON, 120, 90, 90, 7)}),
+        TIER7("Red Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 500, 1_000_000, -1, 40, Npcs.RED_DRAGON,
+                new BossMob[]{new BossMob(Npcs.RED_DRAGON, 150, 110, 110, 8)}),
+        TIER8("Black Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 650, 2_000_000, -1, 45, Npcs.BLACK_DRAGON,
+                new BossMob[]{new BossMob(Npcs.BLACK_DRAGON, 180, 130, 130, 8)}),
+        TIER9("Demon Domain", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 800, 3_000_000, -1, 50, Npcs.BLACK_DEMON,
+                new BossMob[]{new BossMob(Npcs.BLACK_DEMON, 200, 150, 150, 9)}),
+        TIER10("Dragon King", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 1_000, 5_000_000, 11286, 60, Npcs.KING_BLACK_DRAGON,
+                new BossMob[]{new BossMob(Npcs.KING_BLACK_DRAGON, 250, 180, 180, 1)});
 
         static {
             TIER1.requiredKillCountToUnlockNext = 25;  TIER1.nextTier = TIER2;
@@ -118,28 +129,40 @@ public class BossInstanceManager {
         }
 
         private final String zoneName;
+        private final Boundary zoneBoundary;
+        private final Position spawnTile;
         private final int killRequirement;
         private final int gpCost;
         private final int itemRequirement;
         private final int respawnTime;
-        private final int killNpcId;
+        private final int bossNpcId;
         private final BossMob[] mobs;
         private int requiredKillCountToUnlockNext;
         private BossTier nextTier;
 
-        BossTier(String zoneName, int killRequirement, int gpCost, int itemRequirement,
-                 int respawnTime, int killNpcId, BossMob[] mobs) {
+        BossTier(String zoneName, Boundary zoneBoundary, Position spawnTile, int killRequirement, int gpCost, int itemRequirement,
+                 int respawnTime, int bossNpcId, BossMob[] mobs) {
             this.zoneName = zoneName;
+            this.zoneBoundary = zoneBoundary;
+            this.spawnTile = spawnTile;
             this.killRequirement = killRequirement;
             this.gpCost = gpCost;
             this.itemRequirement = itemRequirement;
             this.respawnTime = respawnTime;
-            this.killNpcId = killNpcId;
+            this.bossNpcId = bossNpcId;
             this.mobs = mobs;
         }
 
         public String getZoneName() {
             return zoneName;
+        }
+
+        public Boundary getZoneBoundary() {
+            return zoneBoundary;
+        }
+
+        public Position getSpawnTile() {
+            return spawnTile;
         }
 
         public int getKillRequirement() {
@@ -158,8 +181,8 @@ public class BossInstanceManager {
             return respawnTime;
         }
 
-        public int getKillNpcId() {
-            return killNpcId;
+        public int getBossNpcId() {
+            return bossNpcId;
         }
 
         public BossMob[] getMobs() {
@@ -176,7 +199,7 @@ public class BossInstanceManager {
 
         /** Returns the player's kill count for the NPC associated with this tier. */
         public int getKillCount(Player player) {
-            String name = NpcDef.forId(killNpcId).getName();
+            String name = NpcDef.forId(bossNpcId).getName();
             return player.getNpcDeathTracker().getKc(name);
         }
     }
@@ -195,13 +218,13 @@ public class BossInstanceManager {
             return;
         }
 
-        Boundary bounds = new Boundary(player.getX() - 10, player.getY() - 10,
-                player.getX() + 10, player.getY() + 10);
+        Boundary bounds = tier.getZoneBoundary();
         BossInstanceArea area = new BossInstanceArea(player, tier, bounds);
         INSTANCES.put(player, area);
 
         area.add(player);
-        player.getPA().movePlayerUnconditionally(player.getX(), player.getY(), area.getHeight());
+        Position spawn = tier.getSpawnTile();
+        player.getPA().movePlayerUnconditionally(spawn.getX(), spawn.getY(), area.getHeight());
 
         spawnInstanceGrid(player, tier, area, false);
         BossInstanceOverlayManager.sendKillOverlay(player);
@@ -217,13 +240,13 @@ public class BossInstanceManager {
             return;
         }
 
-        Boundary bounds = new Boundary(player.getX() - 10, player.getY() - 10,
-                player.getX() + 10, player.getY() + 10);
+        Boundary bounds = tier.getZoneBoundary();
         BossInstanceArea area = new BossInstanceArea(player, tier, bounds);
         INSTANCES.put(player, area);
 
         area.add(player);
-        player.getPA().movePlayerUnconditionally(player.getX(), player.getY(), area.getHeight());
+        Position spawn = tier.getSpawnTile();
+        player.getPA().movePlayerUnconditionally(spawn.getX(), spawn.getY(), area.getHeight());
 
         spawnInstanceGrid(player, tier, area, true);
         player.setPreviewingBossInstance(true);
@@ -231,13 +254,11 @@ public class BossInstanceManager {
     }
 
     /**
-     * Spawns NPCs in a grid around the player so the instance feels populated.
-     * NPCs are spaced two tiles apart and up to twenty are spawned from the tier
-     * mob pool.
+     * Spawns NPCs randomly inside the tier's boundary so the instance feels populated.
+     * Each {@link BossMob} defines how many creatures should appear for the tier.
      */
     private static void spawnInstanceGrid(Player player, BossTier tier, BossInstanceArea area, boolean preview) {
-        int baseX = player.getX();
-        int baseY = player.getY();
+        Boundary bounds = tier.getZoneBoundary();
         int height = area.getHeight();
 
         BossMob[] mobs = tier.getMobs();
@@ -245,11 +266,11 @@ public class BossInstanceManager {
             return;
         }
 
-        int spawned = 0;
-        for (int dx = -5; dx <= 5 && spawned < 20; dx += 2) {
-            for (int dy = -5; dy <= 5 && spawned < 20; dy += 2) {
-                BossMob mob = mobs[Misc.random(mobs.length - 1)];
-                NPC npc = NPCSpawning.spawnNpc(player, mob.getNpcId(), baseX + dx, baseY + dy,
+        for (BossMob mob : mobs) {
+            for (int i = 0; i < mob.getCount(); i++) {
+                int x = Misc.random(bounds.getMinimumX() + 1, bounds.getMaximumX() - 1);
+                int y = Misc.random(bounds.getMinimumY() + 1, bounds.getMaximumY() - 1);
+                NPC npc = NPCSpawning.spawnNpc(player, mob.getNpcId(), x, y,
                         height, 0, 0, false, false,
                         NpcStats.builder()
                                 .setHitpoints(mob.getHitpoints())
@@ -266,7 +287,6 @@ public class BossInstanceManager {
                         npc.getBehaviour().setRespawnWhenPlayerOwned(true);
                     }
                     area.add(npc);
-                    spawned++;
                 }
             }
         }

--- a/src/io/xeros/content/instances/BossInstanceOverlayManager.java
+++ b/src/io/xeros/content/instances/BossInstanceOverlayManager.java
@@ -21,10 +21,10 @@ public class BossInstanceOverlayManager {
         int current = player.getTierKillCounts().getOrDefault(tier, 0);
         BossInstanceManager.BossTier next = tier.getNextTier();
 
-//        player.getPA().sendFrame126("\uD83E\uDDF1 Tier: " + BossInstanceManager.getTierDisplayNameSafe(tier), 8144);
-//        player.getPA().sendFrame126("\u2620\uFE0F Kills: " + current + " / " + tier.getRequiredKillCountToUnlockNext(), 8145);
-//        player.getPA().sendFrame126("\uD83D\uDD13 Unlocks: " + (next != null ? BossInstanceManager.getTierDisplayNameSafe(next) : "Maxed"), 8146);
-//        player.getPA().sendFrame126("", 8147);
+        player.getPA().sendFrame126("\uD83E\uDDF1 Tier: " + BossInstanceManager.getTierDisplayNameSafe(tier), 8144);
+        player.getPA().sendFrame126("\u2620\uFE0F Kills: " + current + " / " + tier.getRequiredKillCountToUnlockNext(), 8145);
+        player.getPA().sendFrame126("\uD83D\uDD13 Unlocks: " + (next != null ? BossInstanceManager.getTierDisplayNameSafe(next) : "Maxed"), 8146);
+        player.getPA().sendFrame126("", 8147);
         player.getPA().sendFrame126("", 8148);
     }
 

--- a/src/io/xeros/content/items/aoeweapons/AoeManager.java
+++ b/src/io/xeros/content/items/aoeweapons/AoeManager.java
@@ -10,9 +10,8 @@ import io.xeros.model.collisionmap.doors.Location;
 import io.xeros.model.entity.Entity;
 import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.npc.NPCHandler;
-import io.xeros.model.entity.player.Boundary;
+import io.xeros.content.instances.BossInstanceManager;
 import io.xeros.model.entity.player.Player;
-import io.xeros.model.entity.player.Position;
 import io.xeros.util.Misc;
 
 import java.util.Arrays;
@@ -24,7 +23,8 @@ public class AoeManager {
 
     public static boolean canAOE(Player player) {
 
-        return Boundary.isIn(player, Boundary.AOEInstance) &&
+        BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(player);
+        return area != null && area.isWithinAoeZone(player.getPosition()) &&
                 Arrays.stream(AoeWeapons.values()).anyMatch(i -> i.ID == player.playerEquipment[Player.playerWeapon]);
     }
 
@@ -50,12 +50,16 @@ public class AoeManager {
         player.startAnimation(anim);
 
         if (player.isPlayer() && victim.isNPC()) {
+            BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(player);
             victim.startGraphic(new Graphic(gfx, 0, Graphic.GraphicHeight.MIDDLE));
             for (NPC next : NPCHandler.npcs) {
                 if (next == null) {
                     continue;
                 }
                 if (next.getInstance() != player.getInstance() || next.getHeight() != player.getHeight()) {
+                    continue;
+                }
+                if (area != null && !area.isWithinAoeZone(next.getPosition())) {
                     continue;
                 }
                 if (!player.getPosition().withinDistance(next.getPosition(), range) || next.getHealth().getCurrentHealth() <= 0) {

--- a/src/io/xeros/model/entity/player/Boundary.java
+++ b/src/io/xeros/model/entity/player/Boundary.java
@@ -542,7 +542,7 @@ public class Boundary {
 
 
 	public static final Boundary Wilderness_Slayer = new Boundary(3328, 10048, 3455, 10175);
-	public static final	Boundary AOEInstance = new Boundary(2880, 5440, 2943, 5503);
+	public static final	Boundary AOEInstance = new Boundary(2270, 4758, 2295, 4785);
 	public static final Boundary WILDERNESS = new Boundary(2941, 3525, 3392, 3968);
 	public static final Boundary WILDERNESS_UNDERGROUND = new Boundary(2980, 10048, 3473, 10373);
 	public static final Boundary[] WILDERNESS_PARAMETERS = {WILDERNESS, WILDERNESS_UNDERGROUND, WILDERNESS_GOD_WARS_BOUNDARY, REV_CAVE};


### PR DESCRIPTION
## Summary
- add zone boundary, spawn tile and boss npc id fields to each BossTier
- spawn tier mobs at random positions inside the boundary when entering or previewing an instance
- expose tier boss id for drop table displays
- scale tier mob counts and display kill progress overlay

## Testing
- `gradle --console=plain test` *(fails: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*

------
https://chatgpt.com/codex/tasks/task_e_68928bbe0fd083208e1b5e22f58def78