### PR TITLE
Add Freakazoid hype bot

### DIFF
--- a/src/io/xeros/ServerStartup.java
+++ b/src/io/xeros/ServerStartup.java
@@ -30,6 +30,7 @@ import io.xeros.content.tournaments.TourneyManager;
 import io.xeros.content.trails.TreasureTrailsRewards;
 import io.xeros.content.vote_panel.VotePanelManager;
 import io.xeros.content.wogw.Wogw;
+import io.xeros.content.bots.FreakazoidBot;
 import io.xeros.content.worldevent.WorldEventContainer;
 import io.xeros.model.Npcs;
 import io.xeros.model.collisionmap.ObjectDef;
@@ -167,6 +168,7 @@ public class ServerStartup {
 
         ZamorakGuardian.spawn();
         new SarachnisNpc(Npcs.SARACHNIS, SarachnisNpc.SPAWN_POSITION);
+        FreakazoidBot.spawn();
 
         PlayerSaveBackup.start(Configuration.PLAYER_SAVE_TIMER_MILLIS, Configuration.PLAYER_SAVE_BACKUP_EVERY_X_SAVE_TICKS);
 

--- a/src/io/xeros/content/bots/FreakazoidBot.java
+++ b/src/io/xeros/content/bots/FreakazoidBot.java
@@ -1,0 +1,61 @@
+package io.xeros.content.bots;
+
+import io.xeros.model.cycleevent.CycleEvent;
+import io.xeros.model.cycleevent.CycleEventContainer;
+import io.xeros.model.cycleevent.CycleEventHandler;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.npc.NPCSpawning;
+import io.xeros.model.entity.player.PlayerHandler;
+import io.xeros.model.entity.player.Position;
+import io.xeros.util.Misc;
+
+/**
+ * A persistent NPC that dances and broadcasts hype messages to players.
+ */
+public class FreakazoidBot {
+
+    private static final int NPC_ID = 12345; // Custom dancing robot NPC ID
+    private static final Position SPAWN_POS = new Position(3092, 3505); // Home area
+    private static final int[] DANCE_EMOTES = {866, 2109, 2110, 2106};
+
+    private static final String[] MESSAGES = {
+        "\uD83D\uDD25 Vote daily to help us grow! ::vote \uD83D\uDD25",
+        "\uD83D\uDC8E Donating supports server development! ::donate \uD83D\uDC8E",
+        "\uD83D\uDCA1 Tip: You can exchange unwanted gear in the Fire of Exchange!",
+        "\uD83C\uDFAF Set a goal today: A new drop? A new pet? Let's go!",
+        "\uD83D\uDCE3 Join the Discord for giveaways and events! ::discord"
+    };
+
+    private static NPC bot;
+
+    public static void spawn() {
+        bot = NPCSpawning.spawnNpc(NPC_ID, SPAWN_POS.getX(), SPAWN_POS.getY(), SPAWN_POS.getHeight(), 0, 0);
+        if (bot == null) {
+            return;
+        }
+        bot.revokeWalkingPrivilege = true;
+        bot.isGodmode = true;
+        bot.setAttackable(false);
+        bot.setInvisible(false);
+        bot.setCustomName("@blu@Freakazoid");
+        startBotLoop();
+    }
+
+    private static void startBotLoop() {
+        CycleEventHandler.getSingleton().addEvent(bot, new CycleEvent() {
+            @Override
+            public void execute(CycleEventContainer container) {
+                if (bot == null || bot.isDead()) {
+                    container.stop();
+                    return;
+                }
+
+                int emote = DANCE_EMOTES[Misc.trueRand(DANCE_EMOTES.length)];
+                bot.startAnimation(emote);
+
+                String message = MESSAGES[Misc.trueRand(MESSAGES.length)];
+                PlayerHandler.executeGlobalMessage("@or1@[Freakazoid]@bla@: " + message);
+            }
+        }, 50); // Fires roughly every 30 seconds
+    }
+}

--- a/src/io/xeros/content/combat/core/AttackNpcCheck.java
+++ b/src/io/xeros/content/combat/core/AttackNpcCheck.java
@@ -75,6 +75,10 @@ public class AttackNpcCheck {
         if (ThrallSystem.isThrall(npc.getNpcId())) {
             return false;
         }
+
+        if (!npc.isAttackable()) {
+            return false;
+        }
 //        if (!npc.getPosition().inMulti()) {
             //!npcs[i].getPosition().inMulti() && ((c.underAttackByPlayer > 0 && c.underAttackByNpc != i)
             //        || (c.underAttackByNpc > 0 && c.underAttackByNpc != i))

--- a/src/io/xeros/model/entity/npc/NPC.java
+++ b/src/io/xeros/model/entity/npc/NPC.java
@@ -66,6 +66,13 @@ public class NPC extends Entity {
 
     public boolean isGodmode;
 
+    @Setter
+    @Getter
+    private boolean attackable = true;
+
+    @Setter
+    private String customName;
+
     public int summonedBy;
     public int absX, absY;
     public int heightLevel;
@@ -1374,7 +1381,7 @@ public class NPC extends Entity {
     }
 
     public String getName() {
-        return getDefinition().getName();
+        return customName != null ? customName : getDefinition().getName();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add Freakazoid bot that dances and broadcasts periodic messages
- allow NPCs to be marked unattackable with custom names
- spawn the new hype bot during server startup

## Testing
- `gradle test` *(fails: ScrollConverterDialogue.java:29: class, interface, enum, or record expected)*

------
https://chatgpt.com/codex/tasks/task_e_6892c9c539048320b4148ef063336abc