### PR TITLE
feat: add adaptive boss framework

### DIFF
--- a/src/io/xeros/content/dialogue/impl/ScrollConverterDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/ScrollConverterDialogue.java
@@ -25,5 +25,4 @@ public class ScrollConverterDialogue extends DialogueBuilder {
                 new DialogueOption("Nevermind", p -> p.getPA().closeAllWindows())
         );
     }
-    }
 }

--- a/src/io/xeros/model/entity/npc/AdaptiveBoss.java
+++ b/src/io/xeros/model/entity/npc/AdaptiveBoss.java
@@ -1,0 +1,26 @@
+package io.xeros.model.entity.npc;
+
+/**
+ * Hook callbacks for adaptive boss mechanics. Implement this in a boss class
+ * to customize behaviour when the adaptive mechanics trigger.
+ */
+public interface AdaptiveBoss {
+
+    /**
+     * Called when the boss drops below 50% hitpoints and its special attack
+     * rate is increased.
+     */
+    default void onSpecialBoost(NPC npc) {}
+
+    /**
+     * Called once when the boss drops below 30% hitpoints and default minions
+     * are about to be spawned.
+     */
+    default void onSummonMinions(NPC npc) {}
+
+    /**
+     * Called when the boss enrages after the fight lasts over ninety seconds.
+     */
+    default void onEnrage(NPC npc) {}
+}
+

--- a/src/io/xeros/model/entity/npc/NPC.java
+++ b/src/io/xeros/model/entity/npc/NPC.java
@@ -10,6 +10,7 @@ import io.xeros.content.bosses.Sol;
 import io.xeros.content.bosses.Solak;
 import io.xeros.content.bosses.hydra.AlchemicalHydra;
 import io.xeros.content.bosses.wildypursuit.FragmentOfSeren;
+import io.xeros.model.entity.npc.AdaptiveBoss;
 import io.xeros.content.combat.CombatHit;
 import io.xeros.content.combat.Hitmark;
 import io.xeros.content.combat.common.CombatMethod;
@@ -105,6 +106,21 @@ public class NPC extends Entity {
      */
     public long lastSpecialAttack;
 
+    @Getter
+    @Setter
+    private long specialAttackCooldown = 15000;
+    private long combatStartTime;
+    @Getter
+    @Setter
+    private boolean adaptive;
+    private boolean specialBoosted;
+    private boolean adaptiveMinionsSummoned;
+    @Getter
+    private boolean enraged;
+    @Getter
+    @Setter
+    private AdaptiveBoss adaptiveBoss;
+
     public boolean spawnedMinions;
 
     @Setter
@@ -198,6 +214,9 @@ public class NPC extends Entity {
         clearUpdateFlags();
         fetchDefaultNpcStats();
         setNpcCombatDefinition();
+        if (this.definition.getCombatLevel() >= 100) {
+            enableAdaptive(null);
+        }
         if (this.getNpcStats() != null && this.getNpcStats().scripts != null && this.getNpcStats().scripts.combat_ != null) {
             this.setCombatMethod(this.getNpcStats().scripts.newCombatInstance());
         }
@@ -215,6 +234,9 @@ public class NPC extends Entity {
         if (this.getNpcStats() != null && this.getNpcStats().scripts != null && this.getNpcStats().scripts.combat_ != null) {
             this.setCombatMethod(this.getNpcStats().scripts.newCombatInstance());
         }
+        if (this.definition.getCombatLevel() >= 100) {
+            enableAdaptive(null);
+        }
     }
 
     public NPC(int index, int npcId, NpcDef definition) {
@@ -228,6 +250,9 @@ public class NPC extends Entity {
         setNpcCombatDefinition();
         if (this.getNpcStats() != null && this.getNpcStats().scripts != null && this.getNpcStats().scripts.combat_ != null) {
             this.setCombatMethod(this.getNpcStats().scripts.newCombatInstance());
+        }
+        if (this.definition.getCombatLevel() >= 100) {
+            enableAdaptive(null);
         }
     }
 
@@ -279,6 +304,67 @@ public class NPC extends Entity {
         //this.defence = defaultNpcStats.getDefenceLevel();
         getHealth().setMaximumHealth(getNpcStats().getHitpoints());
         getHealth().reset();
+    }
+
+    public void enableAdaptive(AdaptiveBoss hook) {
+        this.adaptive = true;
+        this.adaptiveBoss = hook;
+    }
+
+    public boolean canUseSpecial() {
+        return System.currentTimeMillis() - lastSpecialAttack > specialAttackCooldown;
+    }
+
+    public void resetSpecialAttack() {
+        lastSpecialAttack = System.currentTimeMillis();
+    }
+
+    public void processAdaptiveMechanics() {
+        if (!adaptive) {
+            return;
+        }
+
+        if (combatStartTime == 0 && (underAttack || playerAttackingIndex > 0 || npcAttackingIndex > 0)) {
+            combatStartTime = System.currentTimeMillis();
+        }
+
+        int max = getHealth().getMaximumHealth();
+        int current = getHealth().getCurrentHealth();
+
+        if (!specialBoosted && current <= max / 2) {
+            specialAttackCooldown = Math.max(1000, specialAttackCooldown / 2);
+            if (adaptiveBoss != null) {
+                adaptiveBoss.onSpecialBoost(this);
+            }
+            specialBoosted = true;
+        }
+
+        if (!adaptiveMinionsSummoned && current <= (int) (max * 0.3)) {
+            if (adaptiveBoss != null) {
+                adaptiveBoss.onSummonMinions(this);
+            } else {
+                summonDefaultMinions();
+            }
+            adaptiveMinionsSummoned = true;
+        }
+
+        if (!enraged && combatStartTime > 0 && System.currentTimeMillis() - combatStartTime > 90_000) {
+            enraged = true;
+            maxHit += (int) Math.ceil(maxHit * 0.5);
+            if (adaptiveBoss != null) {
+                adaptiveBoss.onEnrage(this);
+            }
+        }
+    }
+
+    private void summonDefaultMinions() {
+        for (int offset = -1; offset <= 1; offset += 2) {
+            NPC minion = NPCSpawning.spawnNpc(getNpcId(), absX + offset, absY + offset, heightLevel, 1, Math.max(1, maxHit / 2));
+            if (minion != null) {
+                minion.getBehaviour().setRespawn(false);
+                minion.setAdaptive(false);
+            }
+        }
     }
 
     public boolean canBeAttacked(Entity entity) {

--- a/src/io/xeros/model/entity/npc/NPCProcess.java
+++ b/src/io/xeros/model/entity/npc/NPCProcess.java
@@ -131,6 +131,8 @@ public class NPCProcess {
             }
         }
 
+        npc.processAdaptiveMechanics();
+
         if (npc.actionTimer > 0) {
             npc.actionTimer--;
         }
@@ -146,7 +148,10 @@ public class NPCProcess {
             NPCHitPlayer.applyDamage(npc, npcHandler);
         }
         if (npc.attackTimer > 0) {
-            npc.attackTimer--;
+            npc.attackTimer -= npc.isEnraged() ? 2 : 1;
+            if (npc.attackTimer < 0) {
+                npc.attackTimer = 0;
+            }
         }
         if (npc.getNpcId() == 7553) {
             npc.walkingHome = true;

--- a/src/io/xeros/model/entity/npc/actions/LoadSpell.java
+++ b/src/io/xeros/model/entity/npc/actions/LoadSpell.java
@@ -524,11 +524,11 @@ public class LoadSpell {
                         npc.attackTimer = 7;
                         npc.hitDelayTimer = 4;
                         handler().groundSpell(npc, player, 280, 281, "vetion", 4);
-                    } else if (chance > 90 && System.currentTimeMillis() - npc.lastSpecialAttack > 15000) {
+                    } else if (chance > 90 && npc.canUseSpecial()) {
                         npc.setAttackType(CombatType.SPECIAL);
                         npc.attackTimer = 5;
                         npc.hitDelayTimer = 2;
-                        npc.lastSpecialAttack = System.currentTimeMillis();
+                        npc.resetSpecialAttack();
                     } else {
                         npc.setAttackType(CombatType.MELEE);
                         npc.attackTimer = 5;
@@ -540,11 +540,11 @@ public class LoadSpell {
                         npc.attackTimer = 7;
                         npc.hitDelayTimer = 4;
                         handler().groundSpell(npc, player, 280, 281, "vetion", 4);
-                    } else if (System.currentTimeMillis() - npc.lastSpecialAttack > 15000) {
+                    } else if (npc.canUseSpecial()) {
                         npc.setAttackType(CombatType.SPECIAL);
                         npc.attackTimer = 5;
                         npc.hitDelayTimer = 2;
-                        npc.lastSpecialAttack = System.currentTimeMillis();
+                        npc.resetSpecialAttack();
                     } else {
                         npc.setAttackType(CombatType.MAGE);
                         npc.attackTimer = 7;
@@ -568,11 +568,11 @@ public class LoadSpell {
                         npc.attackTimer = 7;
                         npc.hitDelayTimer = 4;
                         handler().groundSpell(npc, player, 159, 293, "araphel", 4);
-                    } else if (chance > 90 && System.currentTimeMillis() - npc.lastSpecialAttack > 15000) {
+                    } else if (chance > 90 && npc.canUseSpecial()) {
                         npc.setAttackType(CombatType.SPECIAL);
                         npc.attackTimer = 5;
                         npc.hitDelayTimer = 2;
-                        npc.lastSpecialAttack = System.currentTimeMillis();
+                        npc.resetSpecialAttack();
                     } else {
                         npc.setAttackType(CombatType.MELEE);
                         npc.attackTimer = 5;
@@ -584,11 +584,11 @@ public class LoadSpell {
                         npc.attackTimer = 7;
                         npc.hitDelayTimer = 4;
                         handler().groundSpell(npc, player, 159, 293, "araphel", 4);
-                    } else if (System.currentTimeMillis() - npc.lastSpecialAttack > 15000) {
+                    } else if (npc.canUseSpecial()) {
                         npc.setAttackType(CombatType.SPECIAL);
                         npc.attackTimer = 5;
                         npc.hitDelayTimer = 2;
-                        npc.lastSpecialAttack = System.currentTimeMillis();
+                        npc.resetSpecialAttack();
                     } else {
                         npc.setAttackType(CombatType.MAGE);
                         npc.attackTimer = 7;


### PR DESCRIPTION
## Summary
- add `AdaptiveBoss` interface with hooks for special boost, minion spawn, and enrage
- teach `NPC` to run adaptive mechanics: halves special cooldown under 50% HP, summons minions at 30%, and enrages after 90 seconds
- process adaptive behaviour each tick and speed attacks when enraged
- update special attack logic to use adaptive cooldown

## Testing
- `gradle test` *(fails: method isBossAlerts() already defined, GlobalObject position methods missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68938afc93e483209d0120488783645a