### PR TITLE
feat: add demon slayer master

### DIFF
--- a/demonhunter-xp.json
+++ b/demonhunter-xp.json
@@ -1,0 +1,12 @@
+[
+  {"tier":1, "xpMultiplier":2.0},
+  {"tier":2, "xpMultiplier":2.5},
+  {"tier":3, "xpMultiplier":3.0},
+  {"tier":4, "xpMultiplier":3.5},
+  {"tier":5, "xpMultiplier":4.0},
+  {"tier":6, "xpMultiplier":4.5},
+  {"tier":7, "xpMultiplier":5.0},
+  {"tier":8, "xpMultiplier":5.5},
+  {"tier":9, "xpMultiplier":5.8},
+  {"tier":10, "xpMultiplier":6.0}
+]

--- a/src/io/xeros/content/commands/admin/Dhcontract.java
+++ b/src/io/xeros/content/commands/admin/Dhcontract.java
@@ -1,0 +1,48 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.skills.slayer.DemonSlayerContract;
+import io.xeros.content.skills.slayer.DemonSlayerMaster;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Arrays;
+
+/**
+ * Debug command to set or view demon slayer contracts.
+ */
+public class Dhcontract extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        if (input == null || input.isEmpty()) {
+            player.getDemonContract().ifPresentOrElse(c ->
+                    player.sendMessage("Contract: " + c.getTarget().getNpcName() + " x" + c.getAmount()),
+                    () -> player.sendMessage("No active contract."));
+            return;
+        }
+        String[] parts = input.split(" ");
+        String name = parts[0].replace('_', ' ');
+        int amount = 1;
+        if (parts.length > 1) {
+            try {
+                amount = Integer.parseInt(parts[1]);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        DemonSlayerMaster.BossTier boss = Arrays.stream(DemonSlayerMaster.BossTier.values())
+                .filter(b -> b.getNpcName().equalsIgnoreCase(name))
+                .findFirst().orElse(null);
+        if (boss == null) {
+            player.sendMessage("Unknown boss: " + name);
+            return;
+        }
+        player.setDemonContract(new DemonSlayerContract(boss, amount));
+        player.sendMessage("Contract set: defeat " + amount + " " + boss.getNpcName());
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+}

--- a/src/io/xeros/content/commands/admin/Dhmarks.java
+++ b/src/io/xeros/content/commands/admin/Dhmarks.java
@@ -1,0 +1,35 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+/**
+ * Adjust or view Demon Mark currency for debugging.
+ */
+public class Dhmarks extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        if (input == null || input.isEmpty()) {
+            player.sendMessage("Demon Marks: " + player.getDemonMarks());
+            return;
+        }
+        try {
+            int amount = Integer.parseInt(input.trim());
+            if (amount >= 0) {
+                player.addDemonMarks(amount);
+            } else {
+                player.removeDemonMarks(-amount);
+            }
+            player.sendMessage("Demon Marks now: " + player.getDemonMarks());
+        } catch (NumberFormatException e) {
+            player.sendMessage("Use ::dhmarks <amount>");
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+}

--- a/src/io/xeros/content/commands/admin/Dhtask.java
+++ b/src/io/xeros/content/commands/admin/Dhtask.java
@@ -1,0 +1,51 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.skills.slayer.DemonSlayerMaster;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Arrays;
+
+/**
+ * Debug command for demon hunter tasks. Allows admins to assign
+ * a specific demon hunter task or a random one if no arguments
+ * are supplied.
+ */
+public class Dhtask extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        DemonSlayerMaster master = new DemonSlayerMaster();
+        if (input == null || input.isEmpty()) {
+            master.assign(player);
+            player.sendMessage("Random demon hunter task assigned.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        String name = parts[0].replace('_', ' ');
+        int amount = 10;
+        if (parts.length > 1) {
+            try {
+                amount = Integer.parseInt(parts[1]);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        DemonSlayerMaster.BossTier boss = Arrays.stream(DemonSlayerMaster.BossTier.values())
+                .filter(b -> b.getNpcName().equalsIgnoreCase(name))
+                .findFirst().orElse(null);
+        if (boss == null) {
+            player.sendMessage("Unknown boss: " + name);
+            return;
+        }
+        DemonSlayerMaster.DemonSlayerTask task = new DemonSlayerMaster.DemonSlayerTask(boss, amount);
+        player.setDemonHunterTask(task);
+        player.setDemonHunterTaskProgress(amount);
+        player.sendMessage("Task set: " + boss.getNpcName() + " x" + amount);
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+}

--- a/src/io/xeros/content/commands/admin/Reloaddhxps.java
+++ b/src/io/xeros/content/commands/admin/Reloaddhxps.java
@@ -1,0 +1,21 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.skills.slayer.DemonHunterXPTable;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+/** Reloads Demon Hunter XP multipliers from configuration. */
+public class Reloaddhxps extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        DemonHunterXPTable.reload();
+        player.sendMessage("Demon Hunter XP multipliers reloaded.");
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+}

--- a/src/io/xeros/content/commands/all/Dhs.java
+++ b/src/io/xeros/content/commands/all/Dhs.java
@@ -1,0 +1,13 @@
+package io.xeros.content.commands.all;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.skills.slayer.DemonHunterTaskOverlayManager;
+import io.xeros.model.entity.player.Player;
+
+/** Displays the Demon Hunter Slayer information overlay. */
+public class Dhs extends Command {
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        DemonHunterTaskOverlayManager.send(player);
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonHunterSlayerDialogue.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterSlayerDialogue.java
@@ -1,0 +1,152 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.annotate.PostInit;
+import io.xeros.content.dialogue.DialogueBuilder;
+import io.xeros.content.dialogue.DialogueOption;
+import io.xeros.content.skills.Skill;
+import io.xeros.model.Npcs;
+import io.xeros.model.entity.npc.NPCAction;
+import io.xeros.model.entity.npc.NPCSpawning;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+import io.xeros.util.Misc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Dialogue interface for the Demon Hunter Slayer Master NPC.
+ */
+public class DemonHunterSlayerDialogue extends DialogueBuilder {
+
+    private static final int NPC = Npcs.DEMON_HUNTER_MASTER;
+
+    public DemonHunterSlayerDialogue(Player player) {
+        super(player);
+        setNpcId(NPC);
+        npc("Greetings, slayer. How can I assist you on your Demon Hunter journey?");
+        List<DialogueOption> options = new ArrayList<>();
+        options.add(new DialogueOption("What's Demon Hunter Slayer?", this::explainSystem));
+        options.add(new DialogueOption("What are the Demon Hunter Slayer tiers?", this::explainTiers));
+        options.add(new DialogueOption("What are the rewards and XP like?", this::explainRewards));
+        options.add(new DialogueOption("View Current Task", this::viewTask));
+        options.add(new DialogueOption("Abandon Task", this::abandonTask));
+        options.add(new DialogueOption("View Stats / Contract", this::viewStats));
+        options.add(new DialogueOption("Open Reward Shop", this::openShop));
+        if (player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
+            options.add(new DialogueOption("Admin Options", this::adminMenu));
+        }
+        option(options.toArray(new DialogueOption[0]));
+    }
+
+    private void explainSystem(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.npc("Demon Hunter Slayer is an elite slayer mode focused on defeating demon bosses.");
+        builder.npc("You'll receive powerful assignments based on your Demon Hunter level.");
+        builder.npc("Progress builds your streak, earns Slayer XP, and rewards Demon Marks.");
+        builder.npc("Milestones unlock perks and elite tasks, and contracts offer extra rewards.");
+        builder.npc("Track your progress, climb the leaderboard, and claim your glory.");
+        builder.option(new DialogueOption("Got it. Back to menu.", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        player.start(builder);
+    }
+
+    private void viewTask(Player player) {
+        if (player.getDemonHunterTask().isEmpty()) {
+            player.sendMessage("You don't currently have a Demon Hunter task.");
+            return;
+        }
+        DemonHunterTaskOverlayManager.schedule(player);
+        player.sendMessage("Your task overlay has been refreshed.");
+    }
+
+    private void abandonTask(Player player) {
+        if (player.getDemonHunterTask().isEmpty()) {
+            player.sendMessage("You don't have a task to abandon.");
+            return;
+        }
+        player.sendMessage("You have abandoned your current task.");
+        player.setDemonHunterTask(null);
+        player.setDemonHunterTaskProgress(0);
+    }
+
+    private void viewStats(Player player) {
+        int level = player.playerLevel[Skill.DEMON_HUNTER.getId()];
+        int streak = player.getDemonTaskStreak();
+        int marks = player.getDemonMarks();
+        player.sendMessage("Demon Hunter Level: " + level);
+        player.sendMessage("Task Streak: " + streak);
+        player.sendMessage("Demon Marks: " + marks);
+        player.getDemonContract().ifPresentOrElse(
+                c -> player.sendMessage("Active Contract: Defeat " + c.getAmount() + " " + c.getTarget().getNpcName()),
+                () -> player.sendMessage("Active Contract: none"));
+    }
+
+    private void openShop(Player player) {
+        DemonMarkRewardHandler.openShop(player);
+    }
+
+    private void adminMenu(Player player) {
+        if (!player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
+            player.sendMessage("Only admins can access this.");
+            return;
+        }
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.option(
+                new DialogueOption("Assign Task", p -> new DemonSlayerMaster().assign(p)),
+                new DialogueOption("Set Contract", p -> {
+                    DemonSlayerMaster.BossTier[] pool = DemonSlayerMaster.BossTier.values();
+                    DemonSlayerMaster.BossTier boss = pool[Misc.random(pool.length - 1)];
+                    p.setDemonContract(new DemonSlayerContract(boss, 1));
+                    p.sendMessage("Contract set: defeat " + boss.getNpcName());
+                }),
+                new DialogueOption("Add 10 Demon Marks", p -> {
+                    p.addDemonMarks(10);
+                    p.sendMessage("You were given 10 Demon Marks.");
+                }),
+                new DialogueOption("Force contract reset", p -> {
+                    p.setDemonContract(null);
+                    p.sendMessage("Contract cleared.");
+                }),
+                new DialogueOption("View boss XP logs", p -> {
+                    for (DemonSlayerMaster.BossTier bt : DemonSlayerMaster.BossTier.values()) {
+                        int xp = DemonHunterXPTable.getXPFor(bt.getBaseXp(), bt.getTier());
+                        p.sendMessage(bt.getNpcName() + ": base " + bt.getBaseXp() + " -> " + xp);
+                    }
+                }),
+                new DialogueOption("Open Reward Shop", DemonMarkRewardHandler::openShop),
+                new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        player.start(builder);
+    }
+
+    private void explainTiers(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        for (DemonSlayerMaster.Tier tier : DemonSlayerMaster.Tier.values()) {
+            String bosses = Arrays.stream(DemonSlayerMaster.BossTier.values())
+                    .filter(b -> b.getTier() == tier)
+                    .map(DemonSlayerMaster.BossTier::getNpcName)
+                    .collect(Collectors.joining(", "));
+            builder.npc("Tier " + tier.getId() + " (lvl " + tier.getLevelRequirement() + "): " + bosses);
+        }
+        builder.option(new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        player.start(builder);
+    }
+
+    private void explainRewards(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.npc("On-task kills grant full Demon Hunter XP and Marks.");
+        builder.npc("Off-task kills only award 25% of the base XP and no marks.");
+        builder.npc("Higher tiers have larger XP multipliers from the configuration file.");
+        builder.option(new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        player.start(builder);
+    }
+
+    @PostInit
+    public static void init() {
+        NPCSpawning.spawnNpc(Npcs.DEMON_HUNTER_MASTER, 3095, 3500, 0, 0, 0);
+        NPCAction.register(Npcs.DEMON_HUNTER_MASTER, 1,
+                (player, npc) -> player.start(new DemonHunterSlayerDialogue(player)));
+    }
+}
+

--- a/src/io/xeros/content/skills/slayer/DemonHunterTaskManager.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterTaskManager.java
@@ -1,0 +1,58 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.content.skills.Skill;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.player.Player;
+
+import java.util.Optional;
+
+/**
+ * Handles Demon Hunter task progress and completion.
+ */
+public class DemonHunterTaskManager {
+
+    public static void handleKill(Player player, NPC npc) {
+        String name = npc.getDefinition().getName().replace("_", " ");
+        Optional<DemonSlayerMaster.BossTier> bossOpt = DemonSlayerMaster.BossTier.forName(name);
+        if (bossOpt.isEmpty()) {
+            return;
+        }
+        DemonSlayerMaster.BossTier boss = bossOpt.get();
+        int baseXp = boss.getBaseXp();
+
+        if (player.getDemonHunterTask().isPresent() && player.getDemonHunterTask().get().getBoss() == boss) {
+            int remaining = player.getDemonHunterTaskProgress() - 1;
+            player.setDemonHunterTaskProgress(Math.max(0, remaining));
+
+            int xp = DemonHunterXPTable.getXPFor(baseXp, boss.getTier());
+            if (player.getDemonHunterMilestones().contains(10)) {
+                xp = (int) (xp * 1.05);
+            }
+            if (player.getDemonContract().isPresent() && !player.getDemonContract().get().isCompleted()
+                    && player.getDemonContract().get().matches(boss)) {
+                xp *= 2;
+                player.getDemonContract().get().complete();
+                player.sendMessage("\uD83C\uDFAF Bonus contract complete!");
+            }
+            player.addDemonHunterXP(xp);
+            player.getPA().addSkillXPMultiplied(baseXp, Skill.SLAYER.getId(), true);
+            DemonSlayerLeaderboardManager.addXp(player, xp);
+
+            if (remaining <= 0) {
+                player.sendMessage("\uD83C\uDFAF Task Complete: You've slain " + boss.getNpcName() + "! +" + (xp * player.getDemonHunterTask().get().getAmount()) + " Demon Hunter XP");
+                player.incrementDemonTaskStreak();
+                DemonSlayerMilestoneManager.check(player);
+                DemonMarkRewardHandler.reward(player);
+                DemonSlayerLeaderboardManager.taskCompleted(player);
+                player.setDemonHunterTask(null);
+                player.setDemonHunterTaskProgress(0);
+            } else {
+                DemonHunterTaskOverlayManager.send(player);
+            }
+        } else {
+            int xp = DemonHunterXPTable.getOffTaskXP(baseXp);
+            player.addDemonHunterXP(xp);
+            player.getPA().addSkillXPMultiplied(xp, Skill.SLAYER.getId(), true);
+        }
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonHunterTaskOverlayManager.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterTaskOverlayManager.java
@@ -1,0 +1,52 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.content.skills.Skill;
+import io.xeros.model.cycleevent.CycleEvent;
+import io.xeros.model.cycleevent.CycleEventContainer;
+import io.xeros.model.cycleevent.CycleEventHandler;
+import io.xeros.model.entity.player.Player;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Displays Demon Hunter task information to players.
+ */
+public class DemonHunterTaskOverlayManager {
+
+    private static final int EVENT_ID = 9821;
+
+    public static void send(Player player) {
+        player.getDemonHunterTask().ifPresent(task -> {
+            int baseXp = task.getBoss().getBaseXp();
+            int xp = DemonHunterXPTable.getXPFor(baseXp, task.getBoss().getTier());
+            player.sendMessage("\uD83D\uDC80 Demon Hunter Task:");
+            player.sendMessage("Boss: " + task.getBoss().getNpcName());
+            player.sendMessage("Kills Left: " + player.getDemonHunterTaskProgress());
+            player.sendMessage("XP per kill: " + xp);
+            player.sendMessage("Streak: " + player.getDemonTaskStreak() + " | Marks: " + player.getDemonMarks());
+            player.getDemonContract().ifPresent(c -> player.sendMessage("\uD83C\uDFAF Bonus: Defeat " + c.getTarget().getNpcName() + " for 2x XP"));
+            DemonSlayerMaster.Tier.forId(player.getDemonHunterTierUnlocked() + 1).ifPresent(t -> {
+                String bosses = Arrays.stream(DemonSlayerMaster.BossTier.values())
+                        .filter(b -> b.getTier() == t)
+                        .map(DemonSlayerMaster.BossTier::getNpcName)
+                        .collect(Collectors.joining(", "));
+                player.sendMessage("Next Tier (lvl " + t.getLevelRequirement() + "): " + bosses);
+            });
+        });
+    }
+
+    public static void schedule(Player player) {
+        CycleEventHandler.getSingleton().stopEvents(player, EVENT_ID);
+        CycleEventHandler.getSingleton().addEvent(EVENT_ID, player, new CycleEvent() {
+            @Override
+            public void execute(CycleEventContainer container) {
+                if (player.disconnected || player.getDemonHunterTask().isEmpty()) {
+                    container.stop();
+                    return;
+                }
+                send(player);
+            }
+        }, 50);
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonHunterXPTable.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterXPTable.java
@@ -1,0 +1,58 @@
+package io.xeros.content.skills.slayer;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.FileReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility for calculating Demon Hunter experience rewards from base npc experience.
+ */
+public class DemonHunterXPTable {
+
+    private static final String CONFIG = "demonhunter-xp.json";
+    private static final Map<Integer, Double> multipliers = new HashMap<>();
+
+    static {
+        load();
+    }
+
+    private static class XpConfig {
+        int tier;
+        double xpMultiplier;
+    }
+
+    private static void load() {
+        try (FileReader reader = new FileReader(CONFIG)) {
+            List<XpConfig> list = new Gson().fromJson(reader, new TypeToken<List<XpConfig>>(){}.getType());
+            multipliers.clear();
+            for (XpConfig cfg : list) {
+                multipliers.put(cfg.tier, cfg.xpMultiplier);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void reload() {
+        load();
+    }
+
+    /**
+     * Calculate experience for killing a boss on task.
+     */
+    public static int getXPFor(int baseXp, DemonSlayerMaster.Tier tier) {
+        double mult = multipliers.getOrDefault(tier.getId(), 1.0);
+        return (int) (baseXp * mult);
+    }
+
+    /**
+     * Experience for killing a boss off task.
+     */
+    public static int getOffTaskXP(int baseXp) {
+        return (int) (baseXp * 0.25);
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonMarkRewardHandler.java
+++ b/src/io/xeros/content/skills/slayer/DemonMarkRewardHandler.java
@@ -1,0 +1,26 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.model.entity.player.Player;
+
+/**
+ * Handles Demon Mark currency for Demon Hunter tasks.
+ */
+public class DemonMarkRewardHandler {
+
+    public static void reward(Player player) {
+        player.addDemonMarks(1);
+        player.sendMessage("You receive a Demon Mark for your efforts.");
+    }
+
+    public static boolean spend(Player player, int amount) {
+        if (player.getDemonMarks() >= amount) {
+            player.removeDemonMarks(amount);
+            return true;
+        }
+        return false;
+    }
+
+    public static void openShop(Player player) {
+        player.sendMessage("The Demon Mark reward shop is currently unavailable.");
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonSlayerContract.java
+++ b/src/io/xeros/content/skills/slayer/DemonSlayerContract.java
@@ -1,0 +1,36 @@
+package io.xeros.content.skills.slayer;
+
+/**
+ * Represents a bonus demon slayer contract.
+ */
+public class DemonSlayerContract {
+
+    private final DemonSlayerMaster.BossTier target;
+    private final int amount;
+    private boolean completed;
+
+    public DemonSlayerContract(DemonSlayerMaster.BossTier target, int amount) {
+        this.target = target;
+        this.amount = amount;
+    }
+
+    public DemonSlayerMaster.BossTier getTarget() {
+        return target;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public boolean matches(DemonSlayerMaster.BossTier boss) {
+        return target == boss;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void complete() {
+        this.completed = true;
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonSlayerLeaderboardManager.java
+++ b/src/io/xeros/content/skills/slayer/DemonSlayerLeaderboardManager.java
@@ -1,0 +1,49 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.PlayerHandler;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks weekly Demon Hunter statistics.
+ */
+public class DemonSlayerLeaderboardManager {
+
+    private static final Map<String, Integer> XP = new ConcurrentHashMap<>();
+    private static final Map<String, Integer> TASKS = new ConcurrentHashMap<>();
+    private static final Map<String, Integer> STREAKS = new ConcurrentHashMap<>();
+
+    private static String topXpPlayer = "";
+    private static int topXp = 0;
+    private static String topTaskPlayer = "";
+    private static int topTasks = 0;
+    private static String topStreakPlayer = "";
+    private static int topStreak = 0;
+
+    public static void addXp(Player player, int amount) {
+        int total = XP.merge(player.getLoginName(), amount, Integer::sum);
+        if (total > topXp) {
+            topXp = total;
+            topXpPlayer = player.getLoginName();
+            PlayerHandler.executeGlobalMessage("[Demon Slayer] " + player.getDisplayName() + " now leads weekly Demon Hunter XP with " + total + ".");
+        }
+    }
+
+    public static void taskCompleted(Player player) {
+        int tasks = TASKS.merge(player.getLoginName(), 1, Integer::sum);
+        int streak = player.getDemonTaskStreak();
+        STREAKS.put(player.getLoginName(), streak);
+        if (tasks > topTasks) {
+            topTasks = tasks;
+            topTaskPlayer = player.getLoginName();
+            PlayerHandler.executeGlobalMessage("[Demon Slayer] " + player.getDisplayName() + " leads weekly Demon Hunter tasks with " + tasks + ".");
+        }
+        if (streak > topStreak) {
+            topStreak = streak;
+            topStreakPlayer = player.getLoginName();
+            PlayerHandler.executeGlobalMessage("[Demon Slayer] " + player.getDisplayName() + " has the longest Demon Hunter streak at " + streak + ".");
+        }
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonSlayerMaster.java
+++ b/src/io/xeros/content/skills/slayer/DemonSlayerMaster.java
@@ -1,0 +1,154 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.content.skills.Skill;
+import io.xeros.model.Npcs;
+import io.xeros.model.definitions.NpcStats;
+import io.xeros.model.entity.player.Player;
+import io.xeros.util.Misc;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Slayer master dedicated to the Demon Hunter skill. This master only assigns
+ * boss tier tasks and rewards Demon Hunter experience on completion.
+ */
+public class DemonSlayerMaster extends SlayerMaster {
+
+    public DemonSlayerMaster() {
+        // No direct interaction through NPC id for now, so use -1.
+        super(-1, 5, new int[] {0,0,0,0,0,0}, new Task[0]);
+    }
+
+    /** Difficulty tiers used to scale experience rewards. */
+    public enum Tier {
+        TIER1(1, 5),
+        TIER2(2, 15),
+        TIER3(3, 30),
+        TIER4(4, 45),
+        TIER5(5, 60),
+        TIER6(6, 75),
+        TIER7(7, 85),
+        TIER8(8, 90),
+        TIER9(9, 95),
+        TIER10(10, 99);
+
+        private final int id;
+        private final int levelReq;
+
+        Tier(int id, int levelReq) {
+            this.id = id;
+            this.levelReq = levelReq;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public int getLevelRequirement() {
+            return levelReq;
+        }
+
+        public static Optional<Tier> forId(int id) {
+            return Arrays.stream(values()).filter(t -> t.id == id).findFirst();
+        }
+    }
+
+    /**
+     * Boss pool for Demon Hunter tasks. Each boss belongs to a tier and has a
+     * base experience reward.
+     */
+    public enum BossTier {
+        GENERAL_GRAARDOR("General Graardor", Npcs.GENERAL_GRAARDOR, Tier.TIER1),
+        KRIL_TSUTSAROTH("K'ril Tsutsaroth", Npcs.KRIL_TSUTSAROTH, Tier.TIER2),
+        COMMANDER_ZILYANA("Commander Zilyana", Npcs.COMMANDER_ZILYANA, Tier.TIER3),
+        KREE_ARRA("Kree'Arra", Npcs.KREEARRA, Tier.TIER3),
+        CHAOS_FANATIC("Chaos Fanatic", Npcs.CHAOS_FANATIC, Tier.TIER4),
+        VENENATIS("Venenatis", Npcs.VENENATIS, Tier.TIER5),
+        CALLISTO("Callisto", Npcs.CALLISTO, Tier.TIER6),
+        VETION("Vet'ion", Npcs.VETION, Tier.TIER6),
+        SKOTIZO("Skotizo", Npcs.SKOTIZO, Tier.TIER7),
+        GHOST_OF_DARKNESS("Ghost of Darkness", 1429, Tier.TIER8),
+        CRYOMANCER_RANGER("Cryomancer Ranger", 1656, Tier.TIER9),
+        THE_NIGHTMARE("The Nightmare", Npcs.THE_NIGHTMARE, Tier.TIER10);
+
+        private final String npcName;
+        private final int npcId;
+        private final Tier tier;
+
+        BossTier(String npcName, int npcId, Tier tier) {
+            this.npcName = npcName;
+            this.npcId = npcId;
+            this.tier = tier;
+        }
+
+        public String getNpcName() { return npcName; }
+
+        public int getNpcId() { return npcId; }
+
+        public Tier getTier() { return tier; }
+
+        public boolean matches(String other) { return npcName.equalsIgnoreCase(other); }
+
+        public int getBaseXp() {
+            return NpcStats.forId(npcId).getHitpoints();
+        }
+
+        public static Optional<BossTier> forName(String name) {
+            return Arrays.stream(values()).filter(b -> b.matches(name)).findFirst();
+        }
+
+        public static Optional<BossTier> forId(int id) {
+            return Arrays.stream(values()).filter(b -> b.npcId == id).findFirst();
+        }
+    }
+
+    /**
+     * Representation of a demon hunter task.
+     */
+    public static class DemonSlayerTask {
+        private final BossTier boss;
+        private final int amount;
+
+        public DemonSlayerTask(BossTier boss, int amount) {
+            this.boss = boss;
+            this.amount = amount;
+        }
+
+        public BossTier getBoss() { return boss; }
+        public int getAmount() { return amount; }
+    }
+
+    /**
+     * Assigns a new demon hunter task based on the player's Demon Hunter level.
+     */
+    public DemonSlayerTask assign(Player player) {
+        int level = player.playerLevel[Skill.DEMON_HUNTER.getId()];
+
+        for (Tier t : Tier.values()) {
+            if (level >= t.getLevelRequirement() && t.getId() > player.getDemonHunterTierUnlocked()) {
+                player.setDemonHunterTierUnlocked(t.getId());
+                String unlocked = Arrays.stream(BossTier.values())
+                        .filter(b -> b.getTier() == t)
+                        .map(BossTier::getNpcName)
+                        .collect(Collectors.joining(", "));
+                player.sendMessage("\uD83D\uDD13 New Tier Unlocked! You can now be assigned " + unlocked + " (Tier " + t.getId() + ")");
+            }
+        }
+
+        List<BossTier> pool = Arrays.stream(BossTier.values())
+                .filter(b -> level >= b.getTier().getLevelRequirement())
+                .collect(Collectors.toList());
+        if (pool.isEmpty()) {
+            pool = Arrays.asList(BossTier.GENERAL_GRAARDOR);
+        }
+        BossTier boss = pool.get(Misc.random(pool.size() - 1));
+        int amount = 5 + Misc.random(30); // 5-35
+        DemonSlayerTask task = new DemonSlayerTask(boss, amount);
+        player.setDemonHunterTask(task);
+        player.setDemonHunterTaskProgress(amount);
+        DemonHunterTaskOverlayManager.send(player);
+        DemonHunterTaskOverlayManager.schedule(player);
+        return task;
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonSlayerMilestoneManager.java
+++ b/src/io/xeros/content/skills/slayer/DemonSlayerMilestoneManager.java
@@ -1,0 +1,40 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.PlayerHandler;
+
+import java.util.Arrays;
+
+/**
+ * Handles milestone perks for demon slayer tasks.
+ */
+public class DemonSlayerMilestoneManager {
+
+    private static final int[] MILESTONES = {5, 10, 25, 50, 100, 250, 500};
+
+    public static void check(Player player) {
+        int streak = player.getDemonTaskStreak();
+        Arrays.stream(MILESTONES).forEach(milestone -> {
+            if (streak >= milestone && !player.getDemonHunterMilestones().contains(milestone)) {
+                player.getDemonHunterMilestones().add(milestone);
+                switch (milestone) {
+                    case 10:
+                        player.sendMessage("Streak 10: +5% Demon XP");
+                        break;
+                    case 25:
+                        player.sendMessage("Streak 25: +1 task skip per day");
+                        break;
+                    case 50:
+                        player.sendMessage("Streak 50: Elite demons unlocked");
+                        break;
+                    case 100:
+                        player.sendMessage("Streak 100: Bonus loot table rolls");
+                        break;
+                    default:
+                        player.sendMessage("Streak " + milestone + " reached!");
+                }
+                PlayerHandler.executeGlobalMessage("[Demon Slayer] " + player.getDisplayName() + " reached a streak of " + milestone + "!");
+            }
+        });
+    }
+}

--- a/src/io/xeros/model/Npcs.java
+++ b/src/io/xeros/model/Npcs.java
@@ -9560,5 +9560,6 @@ public class Npcs {
     public static final int THE_GREAT_GUARDIAN_2 = 11_455;
     public static final int THE_GREAT_GUARDIAN_3 = 11_456;
     public static final int INSTANCE_MASTER = 9_020;
+    public static final int DEMON_HUNTER_MASTER = 9_021;
 
 }

--- a/src/io/xeros/model/entity/npc/NPCProcess.java
+++ b/src/io/xeros/model/entity/npc/NPCProcess.java
@@ -26,6 +26,7 @@ import io.xeros.content.seasons.ChristmasBoss;
 import io.xeros.content.seasons.HalloweenBoss;
 import io.xeros.content.taskmaster.TaskMasterKills;
 import io.xeros.content.taskmaster.Tasks;
+import io.xeros.content.skills.slayer.DemonHunterTaskManager;
 import io.xeros.model.*;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
@@ -716,6 +717,7 @@ public class NPCProcess {
                             for (Player p : PlayerHandler.getPlayers()) {
                                 if (p.getDisplayName().equalsIgnoreCase(target.slayerPartner)) {
                                     p.getSlayer().killTaskMonster(npc);
+                                    DemonHunterTaskManager.handleKill(p, npc);
                                 }
                             }
                         }
@@ -746,6 +748,7 @@ public class NPCProcess {
                         }
 
                         target.getSlayer().killTaskMonster(npc);
+                        DemonHunterTaskManager.handleKill(target, npc);
                         if (npc.getNpcId() != 239 || npc.getNpcId() != 965 || npc.getNpcId() != 8713 || npc.getNpcId() != 11278) {
                             target.getBossTimers().death(npc);
                         }

--- a/src/io/xeros/model/entity/player/Player.java
+++ b/src/io/xeros/model/entity/player/Player.java
@@ -685,6 +685,14 @@ public class Player extends Entity {
     private final ChargeTrident chargeTrident = new ChargeTrident(this);
     private PlayerMovementState movementState = PlayerMovementState.getDefault();
     private Slayer slayer;
+    private Optional<io.xeros.content.skills.slayer.DemonSlayerMaster.DemonSlayerTask> demonHunterTask = Optional.empty();
+    private int demonHunterTaskProgress;
+    private int demonHunterXP;
+    private int demonTaskStreak;
+    private int demonHunterTierUnlocked;
+    private final java.util.Set<Integer> demonHunterMilestones = new java.util.HashSet<>();
+    private int demonMarks;
+    private Optional<io.xeros.content.skills.slayer.DemonSlayerContract> demonContract = Optional.empty();
     private final AgilityHandler agilityHandler = new AgilityHandler();
     private final PointItems pointItems = new PointItems(this);
     private final GnomeAgility gnomeAgility = new GnomeAgility();
@@ -3016,6 +3024,75 @@ public class Player extends Entity {
     public Slayer getSlayer() {
         if (slayer == null) slayer = new Slayer(this);
         return slayer;
+    }
+
+    public Optional<io.xeros.content.skills.slayer.DemonSlayerMaster.DemonSlayerTask> getDemonHunterTask() {
+        return demonHunterTask;
+    }
+
+    public void setDemonHunterTask(io.xeros.content.skills.slayer.DemonSlayerMaster.DemonSlayerTask task) {
+        this.demonHunterTask = Optional.ofNullable(task);
+    }
+
+    public int getDemonHunterTaskProgress() {
+        return demonHunterTaskProgress;
+    }
+
+    public void setDemonHunterTaskProgress(int progress) {
+        this.demonHunterTaskProgress = progress;
+    }
+
+    public int getDemonHunterXP() {
+        return demonHunterXP;
+    }
+
+    public void addDemonHunterXP(int amount) {
+        this.demonHunterXP += amount;
+        getPA().addSkillXPMultiplied(amount, Skill.DEMON_HUNTER.getId(), true);
+    }
+
+    public int getDemonTaskStreak() {
+        return demonTaskStreak;
+    }
+
+    public void incrementDemonTaskStreak() {
+        demonTaskStreak++;
+    }
+
+    public void resetDemonTaskStreak() {
+        demonTaskStreak = 0;
+    }
+
+    public int getDemonHunterTierUnlocked() {
+        return demonHunterTierUnlocked;
+    }
+
+    public void setDemonHunterTierUnlocked(int tier) {
+        this.demonHunterTierUnlocked = tier;
+    }
+
+    public java.util.Set<Integer> getDemonHunterMilestones() {
+        return demonHunterMilestones;
+    }
+
+    public int getDemonMarks() {
+        return demonMarks;
+    }
+
+    public void addDemonMarks(int amount) {
+        demonMarks += amount;
+    }
+
+    public void removeDemonMarks(int amount) {
+        demonMarks = Math.max(0, demonMarks - amount);
+    }
+
+    public Optional<io.xeros.content.skills.slayer.DemonSlayerContract> getDemonContract() {
+        return demonContract;
+    }
+
+    public void setDemonContract(io.xeros.content.skills.slayer.DemonSlayerContract contract) {
+        this.demonContract = Optional.ofNullable(contract);
     }
 
     public Agility getAgility() {


### PR DESCRIPTION
## Summary
- refactor Demon Hunter Slayer tiers around teleport bosses and load XP multipliers from `demonhunter-xp.json`
- scale Demon Hunter XP using base NPC HP with tier multipliers and nerf off-task rewards
- expand Slayer Master dialogue with tier and reward explanations plus admin debug tools

## Testing
- `gradle test` *(fails: NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*

------
https://chatgpt.com/codex/tasks/task_e_688ecfb005588320b7f2461e47911466