### PR TITLE
Introduce skilling crystals and tiered tool augments

### DIFF
--- a/src/io/xeros/ServerStartup.java
+++ b/src/io/xeros/ServerStartup.java
@@ -58,6 +58,8 @@ import io.xeros.util.ClassGraphHandler;
 import io.xeros.util.Reflection;
 import io.xeros.util.discord.DiscordIntegration;
 import io.xeros.util.offlinestorage.ItemCollection;
+import io.xeros.model.world.objects.GlobalObject;
+import io.xeros.content.tools.ToolAugments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,6 +171,7 @@ public class ServerStartup {
         ZamorakGuardian.spawn();
         new SarachnisNpc(Npcs.SARACHNIS, SarachnisNpc.SPAWN_POSITION);
         FreakazoidBot.init();
+        Server.getGlobalObjects().add(new GlobalObject(ToolAugments.TINKER_TABLE_ID, 3095, 3494, 0, 0, 10, -1));
 
         PlayerSaveBackup.start(Configuration.PLAYER_SAVE_TIMER_MILLIS, Configuration.PLAYER_SAVE_BACKUP_EVERY_X_SAVE_TICKS);
 

--- a/src/io/xeros/content/commands/admin/Debugtinker.java
+++ b/src/io/xeros/content/commands/admin/Debugtinker.java
@@ -1,0 +1,34 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/**
+ * Lists recent tinker table actions for debugging.
+ */
+public class Debugtinker extends Command {
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        if (player.getTinkerLogs().isEmpty()) {
+            player.sendMessage("No tinker activity logged.");
+            return;
+        }
+        int i = 1;
+        for (String log : player.getTinkerLogs()) {
+            player.sendMessage(i++ + ". " + log);
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("Show recent tinker table logs");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Givecrystal.java
+++ b/src/io/xeros/content/commands/admin/Givecrystal.java
@@ -1,0 +1,43 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.skills.Skill;
+import io.xeros.content.tools.ToolAugments;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+public class Givecrystal extends Command {
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        String[] parts = input.split(" ");
+        if (parts.length < 2) {
+            player.sendMessage("Usage: ::givecrystal <skill> <amount>");
+            return;
+        }
+        try {
+            Skill skill = Skill.valueOf(parts[0].toUpperCase());
+            int amount = Integer.parseInt(parts[1]);
+            int crystalId = ToolAugments.SKILLING_CRYSTALS.getOrDefault(skill, -1);
+            if (crystalId <= 0) {
+                player.sendMessage("No crystal for that skill.");
+                return;
+            }
+            player.getItems().addItem(crystalId, amount);
+            player.sendMessage("Gave " + amount + " crystals for " + skill.name().toLowerCase() + ".");
+        } catch (Exception e) {
+            player.sendMessage("Invalid skill or amount.");
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("Give skilling crystals");
+    }
+}

--- a/src/io/xeros/content/commands/all/Burnhistory.java
+++ b/src/io/xeros/content/commands/all/Burnhistory.java
@@ -1,0 +1,29 @@
+package io.xeros.content.commands.all;
+
+import io.xeros.content.commands.Command;
+import io.xeros.model.entity.player.Player;
+
+import java.util.Optional;
+
+/**
+ * Shows last 10 Fire of Exchange burns.
+ */
+public class Burnhistory extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        if (player.getBurnHistory().isEmpty()) {
+            player.sendMessage("No recent burns recorded.");
+            return;
+        }
+        int i = 1;
+        for (String log : player.getBurnHistory()) {
+            player.sendMessage(i++ + ". " + log);
+        }
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("Shows last 10 Fire of Exchange burns.");
+    }
+}

--- a/src/io/xeros/content/fireofexchange/FireOfExchange.java
+++ b/src/io/xeros/content/fireofexchange/FireOfExchange.java
@@ -22,6 +22,7 @@ import io.xeros.model.items.ItemAssistant;
 import io.xeros.util.Misc;
 import io.xeros.util.discord.Discord;
 import io.xeros.util.logging.player.FireOfExchangeLog;
+import io.xeros.content.tools.ToolAugments;
 
 import java.util.List;
 import java.util.Objects;
@@ -181,6 +182,25 @@ public class FireOfExchange {
         c.getRecentlyDissolvedPrices().add(exchangePrice);
         GlobalBossActivityManager.record(ActivityType.FOE_BURN, (int) exchangePrice);
         Server.getLogging().write(new FireOfExchangeLog(c, new GameItem(c.currentExchangeItem, c.currentExchangeItemAmount)));
+        ToolAugments.unlockFromBurn(c, c.currentExchangeItem);
+        Skill skill = ToolAugments.getSkillForTool(c.currentExchangeItem);
+        boolean crystal = false;
+        if (skill != null && Math.random() < 0.10) {
+            int crystalId = ToolAugments.SKILLING_CRYSTALS.getOrDefault(skill, -1);
+            if (crystalId > 0) {
+                c.getItems().addItem(crystalId, 1);
+                c.sendMessage("The flames return a skilling crystal.");
+                crystal = true;
+            }
+        }
+        String log = ItemAssistant.getItemName(c.currentExchangeItem);
+        if (crystal) {
+            log += " -> crystal";
+        }
+        c.getBurnHistory().addFirst(log);
+        if (c.getBurnHistory().size() > 10) {
+            c.getBurnHistory().removeLast();
+        }
     }
 
     /**

--- a/src/io/xeros/content/items/UseItem.java
+++ b/src/io/xeros/content/items/UseItem.java
@@ -64,6 +64,7 @@ import io.xeros.model.items.ImmutableItem;
 import io.xeros.model.items.ItemCombination;
 import io.xeros.util.Misc;
 import io.xeros.util.logging.player.ItemOnItemLog;
+import io.xeros.content.tools.ToolAugments;
 
 import java.util.Arrays;
 import java.util.List;
@@ -205,11 +206,14 @@ public class UseItem {
 			return;
 		}
 
-		switch (objectID) {
-			case 33311:
-				c.objectYOffset = 5;
-				c.objectXOffset = 5;
-				c.objectDistance = 5;
+                switch (objectID) {
+                        case ToolAugments.TINKER_TABLE_ID:
+                                ToolAugments.useOnTable(c, itemId);
+                                break;
+                        case 33311:
+                                c.objectYOffset = 5;
+                                c.objectXOffset = 5;
+                                c.objectDistance = 5;
 
 				switch (itemId) {
 					case 9698:

--- a/src/io/xeros/content/skills/Fishing.java
+++ b/src/io/xeros/content/skills/Fishing.java
@@ -17,6 +17,8 @@ import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.model.items.ItemAssistant;
 import io.xeros.util.Misc;
+import io.xeros.content.tools.ToolAugments;
+import io.xeros.content.skills.Skill;
 
 import static io.xeros.content.skills.Cooking.cookThisFood;
 import static io.xeros.content.skills.Cooking.fishIds;
@@ -248,8 +250,12 @@ public class Fishing extends SkillHandler {
 								if (player.getPerkSytem().gameItems.stream().anyMatch(item -> item.getId() == 33100) && Misc.random(0,100) <= 10) {
 									amt *= 3;
 								}
-								if (!player.isBot())
-									player.getItems().addItem(player.playerSkillProp[10][1], amt);
+                                                                if (!player.isBot()) {
+                                                                        player.getItems().addItem(player.playerSkillProp[10][1], amt);
+                                                                        if (ToolAugments.rollDoubleGather(player, player.playerSkillProp[10][4])) {
+                                                                                player.getItems().addItem(player.playerSkillProp[10][1], amt);
+                                                                        }
+                                                                }
 
 							}
 							player.startAnimation(player.playerSkillProp[10][0]);
@@ -321,19 +327,26 @@ public class Fishing extends SkillHandler {
 								break;
 						}
 
-						if (experience > 0) {
-							player.getPA().addSkillXPMultiplied((int)(experience), Player.playerFishing, true);
-						}
-						if (player.playerSkillProp[10][3] > 0) {
-							player.getItems().deleteItem(player.playerSkillProp[10][3], player.getItems().getInventoryItemSlot(player.playerSkillProp[10][3]), 1);
+                                               if (experience > 0) {
+                                                       int xp = (int) experience;
+                                                       xp = ToolAugments.applyXpBoost(player, player.playerSkillProp[10][4], xp);
+                                                       player.getPA().addSkillXPMultiplied(xp, Player.playerFishing, true);
+                                                       ToolAugments.decrementDurability(player, player.playerSkillProp[10][4]);
+                                                       ToolAugments.tryGiveCrystal(player, Skill.FISHING);
+                                               }
+                                               if (player.playerSkillProp[10][3] > 0) {
+                                                       boolean preserve = ToolAugments.rollSaveResource(player, player.playerSkillProp[10][4]);
+                                                       if (!preserve) {
+                                                               player.getItems().deleteItem(player.playerSkillProp[10][3], player.getItems().getInventoryItemSlot(player.playerSkillProp[10][3]), 1);
 
-							if (!player.getItems().playerHasItem(player.playerSkillProp[10][3])) {
-								player.sendMessage("You haven't got any " + ItemAssistant.getItemName(player.playerSkillProp[10][3]) + " left!");
-								player.sendMessage("You need " + ItemAssistant.getItemName(player.playerSkillProp[10][3]) + " to fish here.");
-								stop();
-								resetFishing(player);
-							}
-						}
+                                                               if (!player.getItems().playerHasItem(player.playerSkillProp[10][3])) {
+                                                                       player.sendMessage("You haven't got any " + ItemAssistant.getItemName(player.playerSkillProp[10][3]) + " left!");
+                                                                       player.sendMessage("You need " + ItemAssistant.getItemName(player.playerSkillProp[10][3]) + " to fish here.");
+                                                                       stop();
+                                                                       resetFishing(player);
+                                                               }
+                                                       }
+                                               }
 						if (!hasFishingEquipment(player, player.playerSkillProp[10][4])) {
 							stop();
 							resetFishing(player);

--- a/src/io/xeros/content/skills/mining/MiningEvent.java
+++ b/src/io/xeros/content/skills/mining/MiningEvent.java
@@ -29,6 +29,7 @@ import io.xeros.model.world.objects.GlobalObject;
 import io.xeros.util.Location3D;
 import io.xeros.util.Misc;
 import org.apache.commons.lang3.RandomUtils;
+import io.xeros.content.tools.ToolAugments;
 
 /**
  * Represents a singular event that is executed when a player attempts to mine.
@@ -260,7 +261,11 @@ public class MiningEvent extends Event<Player> {
 		if (BoostScrolls.checkHarvestBoost(attachment)) {
 			osrsExperience *= 1.15;
 		}
-		attachment.getPA().addSkillXPMultiplied((int) osrsExperience, Skill.MINING.getId(), true);
+                attachment.getPA().addSkillXPMultiplied(
+                        ToolAugments.applyXpBoost(attachment, pickaxe.getItemId(), (int) osrsExperience),
+                        Skill.MINING.getId(), true);
+                ToolAugments.decrementDurability(attachment, pickaxe.getItemId());
+                ToolAugments.tryGiveCrystal(attachment, Skill.MINING);
 		switch (mineral) {
 			case ADAMANT:
 				break;
@@ -367,8 +372,12 @@ public class MiningEvent extends Event<Player> {
                 if (!attachment.isBot()) {
                         if (attachment.playerEquipment[Player.playerWeapon] == 25112 || attachment.playerEquipmentCosmetic[Player.playerWeapon] == 25112)
                                 attachment.getItems().addItemToBankOrDrop(itemId, amount);
-                        else
+                        else {
                                 attachment.getItems().addItem(itemId, amount);
+                                if (ToolAugments.rollDoubleGather(attachment, pickaxe.getItemId())) {
+                                        attachment.getItems().addItem(itemId, amount);
+                                }
+                        }
                 }
 
 		attachment.sendSpamMessage("You just mined some " + mineral.name().toLowerCase() + ".");//restart that so i can do client side  once i got these done i can send u other skilling messages if needed

--- a/src/io/xeros/content/skills/woodcutting/WoodcuttingEvent.java
+++ b/src/io/xeros/content/skills/woodcutting/WoodcuttingEvent.java
@@ -24,6 +24,7 @@ import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.model.entity.player.Position;
 import io.xeros.model.world.objects.GlobalObject;
 import io.xeros.util.Misc;
+import io.xeros.content.tools.ToolAugments;
 
 import java.util.Optional;
 
@@ -143,7 +144,9 @@ public class WoodcuttingEvent extends Event<Player> {
                 else
                     attachment.getItems().addItem(tree.getWood(), 9);
             }
-            attachment.getPA().addSkillXPMultiplied((int) osrsExperience, Skill.WOODCUTTING.getId(), true);
+            attachment.getPA().addSkillXPMultiplied(ToolAugments.applyXpBoost(attachment, hatchet.getItemId(), (int) osrsExperience),
+                    Skill.WOODCUTTING.getId(), true);
+            ToolAugments.decrementDurability(attachment, hatchet.getItemId());
             handleRewards();
             Hespori.deleteEventItems(attachment);
             attachment.getPA().addSkillXPMultiplied(330, 19, true);
@@ -163,9 +166,19 @@ public class WoodcuttingEvent extends Event<Player> {
             }
             if (attachment.isBot())
                 attachment.getItems().addItemToBankOrDrop(tree.getWood(), SkillcapePerks.WOODCUTTING.isWearing(attachment) || SkillcapePerks.isWearingMaxCape(attachment) ? 2 : 1);
-            else
-                attachment.getItems().addItem(tree.getWood(), SkillcapePerks.WOODCUTTING.isWearing(attachment) || SkillcapePerks.isWearingMaxCape(attachment) ? 2 : 1);
-            attachment.getPA().addSkillXPMultiplied(attachment.playerLevel[Skill.WOODCUTTING.getId()] * 4, 8, true);
+            else {
+                int amt = SkillcapePerks.WOODCUTTING.isWearing(attachment) || SkillcapePerks.isWearingMaxCape(attachment) ? 2 : 1;
+                attachment.getItems().addItem(tree.getWood(), amt);
+                if (ToolAugments.rollDoubleGather(attachment, hatchet.getItemId())) {
+                    attachment.getItems().addItem(tree.getWood(), amt);
+                }
+            }
+            int xp = attachment.playerLevel[Skill.WOODCUTTING.getId()] * 4;
+            attachment.getPA().addSkillXPMultiplied(
+                    ToolAugments.applyXpBoost(attachment, hatchet.getItemId(), xp),
+                    8, true);
+            ToolAugments.decrementDurability(attachment, hatchet.getItemId());
+            ToolAugments.tryGiveCrystal(attachment, Skill.WOODCUTTING);
             attachment.startAnimation(hatchet.getAnimation());
             return;
         }
@@ -189,11 +202,18 @@ public class WoodcuttingEvent extends Event<Player> {
 
             if (attachment.isBot())
                 attachment.getItems().addItemToBankOrDrop(tree.getWood(), 1);
-            else
+            else {
                 attachment.getItems().addItem(tree.getWood(), 1);
+                if (ToolAugments.rollDoubleGather(attachment, hatchet.getItemId())) {
+                    attachment.getItems().addItem(tree.getWood(), 1);
+                }
+            }
             attachment.sendSpamMessage("You get some logs.");
             attachment.getEventCalendar().progress(EventChallenge.CUT_DOWN_X_MAGIC_LOGS);
-            attachment.getPA().addSkillXPMultiplied((int) osrsExperience, Skill.WOODCUTTING.getId(), true);
+            attachment.getPA().addSkillXPMultiplied(ToolAugments.applyXpBoost(attachment, hatchet.getItemId(), (int) osrsExperience),
+                    Skill.WOODCUTTING.getId(), true);
+            ToolAugments.decrementDurability(attachment, hatchet.getItemId());
+            ToolAugments.tryGiveCrystal(attachment, Skill.WOODCUTTING);
             Achievements.increase(attachment, AchievementType.WOODCUT, 1);
             attachment.getPA().sendSound(472);
             handleRewards();
@@ -205,7 +225,10 @@ public class WoodcuttingEvent extends Event<Player> {
             if (Misc.random(chopChance) == 1 || chops >= tree.getChopsRequired()) {
                 chops = 0;
                 int random = Misc.random(4);
-                attachment.getPA().addSkillXPMultiplied((int) osrsExperience, Skill.WOODCUTTING.getId(), true);
+                attachment.getPA().addSkillXPMultiplied(
+                        ToolAugments.applyXpBoost(attachment, hatchet.getItemId(), (int) osrsExperience),
+                        Skill.WOODCUTTING.getId(), true);
+                ToolAugments.decrementDurability(attachment, hatchet.getItemId());
                 Achievements.increase(attachment, AchievementType.WOODCUT, 1);
                 if (attachment.getItems().isWearingItem(25066)
                         || (attachment.getItems().isWearingItem(13241) || attachment.getItems().playerHasItem(13241))

--- a/src/io/xeros/content/tools/AugmentInstance.java
+++ b/src/io/xeros/content/tools/AugmentInstance.java
@@ -1,0 +1,48 @@
+package io.xeros.content.tools;
+
+/**
+ * Represents an applied augment on a specific tool, tracking rarity and durability.
+ */
+public class AugmentInstance {
+    private final ToolAugment augment;
+    private AugmentTier tier;
+    private int durability;
+
+    public AugmentInstance(ToolAugment augment, AugmentTier tier, int durability) {
+        this.augment = augment;
+        this.tier = tier;
+        this.durability = durability;
+    }
+
+    public ToolAugment getAugment() {
+        return augment;
+    }
+
+    public AugmentTier getTier() {
+        return tier;
+    }
+
+    public void setTier(AugmentTier tier) {
+        this.tier = tier;
+    }
+
+    public int getDurability() {
+        return durability;
+    }
+
+    public void setDurability(int durability) {
+        this.durability = durability;
+    }
+
+    /** Reduce durability by one action. */
+    public void degrade() {
+        if (durability > 0) {
+            durability--;
+        }
+    }
+
+    /** Whether this augment is active (has durability remaining). */
+    public boolean isActive() {
+        return durability != 0; // 0 or negative = inactive
+    }
+}

--- a/src/io/xeros/content/tools/AugmentTier.java
+++ b/src/io/xeros/content/tools/AugmentTier.java
@@ -1,0 +1,52 @@
+package io.xeros.content.tools;
+
+/**
+ * Tiers for skilling augments.
+ */
+public enum AugmentTier {
+    BASIC(0.02, 0.05, 0.0, 1, 0),
+    ENHANCED(0.04, 0.10, 0.01, 2, 10_000_000),
+    MASTERWORK(0.06, 0.15, 0.03, 3, 50_000_000);
+
+    private final double xpBoost;
+    private final double saveChance;
+    private final double doubleChance;
+    private final int crystalCost;
+    private final int xpRequired;
+
+    AugmentTier(double xpBoost, double saveChance, double doubleChance, int crystalCost, int xpRequired) {
+        this.xpBoost = xpBoost;
+        this.saveChance = saveChance;
+        this.doubleChance = doubleChance;
+        this.crystalCost = crystalCost;
+        this.xpRequired = xpRequired;
+    }
+
+    public double getXpBoost() {
+        return xpBoost;
+    }
+
+    public double getSaveChance() {
+        return saveChance;
+    }
+
+    public double getDoubleChance() {
+        return doubleChance;
+    }
+
+    public int getCrystalCost() {
+        return crystalCost;
+    }
+
+    public int getXpRequired() {
+        return xpRequired;
+    }
+
+    /**
+     * Get the next tier above this one, or this if masterwork.
+     */
+    public AugmentTier upgrade() {
+        int next = ordinal() + 1;
+        return next < values().length ? values()[next] : this;
+    }
+}

--- a/src/io/xeros/content/tools/ToolAugment.java
+++ b/src/io/xeros/content/tools/ToolAugment.java
@@ -1,0 +1,42 @@
+package io.xeros.content.tools;
+
+/**
+ * Represents a passive perk that can be applied to skilling tools.
+ */
+public enum ToolAugment {
+    /** General skilling augment providing tiered bonuses. */
+    PROFICIENCY(0, "Skilling proficiency augment", true),
+    /** Focus augment used for set bonuses. */
+    FOCUS(995, "Focus augment", false);
+
+    private final int unlockItemId;
+    private final String description;
+    private final boolean stackable;
+
+    ToolAugment(int unlockItemId, String description, boolean stackable) {
+        this.unlockItemId = unlockItemId;
+        this.description = description;
+        this.stackable = stackable;
+    }
+
+    /**
+     * Item id that must be burnt in the Fire of Exchange to unlock this augment.
+     */
+    public int getUnlockItemId() {
+        return unlockItemId;
+    }
+
+    /**
+     * Textual description of the augment's effect.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /** Whether multiple copies of this augment may be stacked on a single tool. */
+    public boolean isStackable() {
+        return stackable;
+    }
+
+    // Effects are handled by the AugmentTier.
+}

--- a/src/io/xeros/content/tools/ToolAugments.java
+++ b/src/io/xeros/content/tools/ToolAugments.java
@@ -1,0 +1,281 @@
+package io.xeros.content.tools;
+
+import io.xeros.content.skills.Fishing;
+import io.xeros.content.skills.Skill;
+import io.xeros.content.skills.mining.Pickaxe;
+import io.xeros.content.skills.woodcutting.Hatchet;
+import io.xeros.model.entity.player.Player;
+
+import java.util.*;
+
+/**
+ * Utility methods for tool augments and the Tinker Table.
+ */
+public class ToolAugments {
+
+    /** Object id for the Tinker Table. */
+    public static final int TINKER_TABLE_ID = 33408;
+    /** Item id for tinker shards. Placeholder value. */
+    public static final int TINKER_SHARD_ID = 5022;
+    /** Default actions before an augment runs out. */
+    public static final int DEFAULT_DURABILITY = 1000;
+    /** Maximum augments per tool. */
+    public static final int MAX_AUGMENTS_PER_TOOL = 2;
+
+    /** Mapping of skill to crystal item id. */
+    public static final Map<Skill, Integer> SKILLING_CRYSTALS = new HashMap<>();
+
+    private static final Set<Integer> TOOL_IDS = new HashSet<>();
+    private static final Map<Integer, Skill> TOOL_SKILLS = new HashMap<>();
+
+    static {
+        SKILLING_CRYSTALS.put(Skill.WOODCUTTING, 6000);
+        SKILLING_CRYSTALS.put(Skill.MINING, 6001);
+        SKILLING_CRYSTALS.put(Skill.FISHING, 6002);
+
+        for (Pickaxe pickaxe : Pickaxe.values()) {
+            TOOL_IDS.add(pickaxe.getItemId());
+            TOOL_SKILLS.put(pickaxe.getItemId(), Skill.MINING);
+        }
+        for (Hatchet hatchet : Hatchet.values()) {
+            TOOL_IDS.add(hatchet.getItemId());
+            TOOL_SKILLS.put(hatchet.getItemId(), Skill.WOODCUTTING);
+        }
+        for (int[] data : Fishing.data) {
+            if (data[2] > 0) {
+                TOOL_IDS.add(data[2]);
+                TOOL_SKILLS.put(data[2], Skill.FISHING);
+            }
+        }
+    }
+
+    /** Unlock augment from burning an item. */
+    public static void unlockFromBurn(Player player, int itemId) {
+        for (ToolAugment augment : ToolAugment.values()) {
+            if (augment.getUnlockItemId() == itemId && player.getUnlockedToolAugments().add(augment)) {
+                player.sendMessage("You can now apply the " + augment.getDescription() + " augment.");
+            }
+        }
+    }
+
+    public static boolean isTool(int itemId) {
+        return TOOL_IDS.contains(itemId);
+    }
+
+    public static Skill getSkillForTool(int itemId) {
+        return TOOL_SKILLS.get(itemId);
+    }
+
+    /** Apply or remove an augment when used on the Tinker Table. */
+    public static void useOnTable(Player player, int itemId) {
+        if (!isTool(itemId)) {
+            player.sendMessage("Only skilling tools can be augmented here.");
+            return;
+        }
+
+        if (applyOrUpgradeProficiency(player, itemId)) {
+            return;
+        }
+
+        if (player.getUnlockedToolAugments().contains(ToolAugment.FOCUS)) {
+            toggleAugment(player, itemId, ToolAugment.FOCUS);
+            return;
+        }
+
+        player.sendMessage("You have no augments unlocked for this tool.");
+    }
+
+    private static boolean applyOrUpgradeProficiency(Player player, int itemId) {
+        Skill skill = getSkillForTool(itemId);
+        if (skill == null) {
+            return false;
+        }
+
+        int crystalId = SKILLING_CRYSTALS.getOrDefault(skill, -1);
+        List<AugmentInstance> list = player.getToolAugments().computeIfAbsent(itemId, k -> new ArrayList<>());
+        AugmentInstance inst = list.stream()
+                .filter(i -> i.getAugment() == ToolAugment.PROFICIENCY)
+                .findFirst().orElse(null);
+
+        AugmentTier next = inst == null ? AugmentTier.BASIC : inst.getTier().upgrade();
+        if (inst != null && inst.getTier() == AugmentTier.MASTERWORK) {
+            list.remove(inst);
+            player.sendMessage("Removed skilling augment from your tool.");
+            return true;
+        }
+
+        int owned = player.getItems().getItemCount(crystalId, false);
+        player.sendMessage("Tinker Table: Tier " + next.name().toLowerCase() + " requires " + next.getCrystalCost() +
+                " crystals. You have " + owned + ".");
+        if (player.playerXP[skill.getId()] < next.getXpRequired()) {
+            player.sendMessage("You need " + next.getXpRequired() + " " + skill.name().toLowerCase() +
+                    " XP to unlock this tier.");
+            return true;
+        }
+        if (owned < next.getCrystalCost()) {
+            player.sendMessage("You do not have enough crystals.");
+            return true;
+        }
+        player.getItems().deleteItem(crystalId, next.getCrystalCost());
+        if (inst == null) {
+            list.add(new AugmentInstance(ToolAugment.PROFICIENCY, next, DEFAULT_DURABILITY));
+            player.sendMessage("Applied " + next.name().toLowerCase() + " augment.");
+        } else {
+            inst.setTier(next);
+            inst.setDurability(DEFAULT_DURABILITY);
+            player.sendMessage("Upgraded augment to " + next.name().toLowerCase() + ".");
+        }
+        player.getTinkerLogs().addFirst("Augment " + next.name());
+        if (player.getTinkerLogs().size() > 10) {
+            player.getTinkerLogs().removeLast();
+        }
+        checkSetBonuses(player);
+        return true;
+    }
+
+    private static void toggleAugment(Player player, int itemId, ToolAugment augment) {
+        List<AugmentInstance> list = player.getToolAugments().computeIfAbsent(itemId, k -> new ArrayList<>());
+        for (Iterator<AugmentInstance> it = list.iterator(); it.hasNext();) {
+            AugmentInstance i = it.next();
+            if (i.getAugment() == augment) {
+                it.remove();
+                player.sendMessage("Removed " + augment.getDescription() + " from your tool.");
+                checkSetBonuses(player);
+                return;
+            }
+        }
+        if (list.size() >= MAX_AUGMENTS_PER_TOOL) {
+            player.sendMessage("This tool cannot hold any more augments.");
+            return;
+        }
+        list.add(new AugmentInstance(augment, AugmentTier.BASIC, DEFAULT_DURABILITY));
+        player.sendMessage("Applied " + augment.getDescription() + " to your tool.");
+        checkSetBonuses(player);
+    }
+
+    /** Notify player of active augments on equip. */
+    public static void onEquip(Player player, int itemId) {
+        List<AugmentInstance> list = player.getToolAugments().get(itemId);
+        if (list != null && !list.isEmpty()) {
+            StringBuilder builder = new StringBuilder("Augments active: ");
+            boolean first = true;
+            for (AugmentInstance inst : list) {
+                if (!inst.isActive()) continue;
+                if (!first) builder.append(", ");
+                builder.append(inst.getAugment().getDescription())
+                        .append(" (")
+                        .append(inst.getTier().name().toLowerCase())
+                        .append(", ")
+                        .append(inst.getDurability())
+                        .append(")");
+                first = false;
+            }
+            if (!first) {
+                player.sendMessage(builder.toString());
+            }
+        }
+        checkSetBonuses(player);
+    }
+
+    /** Apply XP boost if the tool has the proficiency augment or set bonuses. */
+    public static int applyXpBoost(Player player, int itemId, int xp) {
+        double multiplier = 1.0;
+        List<AugmentInstance> list = player.getToolAugments().get(itemId);
+        if (list != null) {
+            for (AugmentInstance inst : list) {
+                if (inst.isActive() && inst.getAugment() == ToolAugment.PROFICIENCY) {
+                    multiplier += inst.getTier().getXpBoost();
+                }
+            }
+        }
+        if (player.isPrecisionSetActive()) {
+            multiplier += 0.05; // precision set bonus
+        }
+        return (int) Math.round(xp * multiplier);
+    }
+
+    /** Chance to save a resource such as bait. */
+    public static boolean rollSaveResource(Player player, int itemId) {
+        List<AugmentInstance> list = player.getToolAugments().get(itemId);
+        if (list == null) return false;
+        for (AugmentInstance inst : list) {
+            if (inst.isActive() && inst.getAugment() == ToolAugment.PROFICIENCY) {
+                return Math.random() < inst.getTier().getSaveChance();
+            }
+        }
+        return false;
+    }
+
+    /** Chance to gather an additional resource. */
+    public static boolean rollDoubleGather(Player player, int itemId) {
+        List<AugmentInstance> list = player.getToolAugments().get(itemId);
+        if (list == null) return false;
+        for (AugmentInstance inst : list) {
+            if (inst.isActive() && inst.getAugment() == ToolAugment.PROFICIENCY) {
+                return Math.random() < inst.getTier().getDoubleChance();
+            }
+        }
+        return false;
+    }
+
+    /** Attempt to drop a crystal while skilling. */
+    public static void tryGiveCrystal(Player player, Skill skill) {
+        long now = System.currentTimeMillis();
+        if (now - player.getCrystalHourStart() > 60_000L * 60) {
+            player.setCrystalHourStart(now);
+            player.setCrystalsFoundThisHour(0);
+        }
+        if (player.getCrystalsFoundThisHour() >= 3) {
+            return;
+        }
+        double chance = 1.0 / 200.0;
+        if (player.wearingFullSkillingOutfit()) {
+            chance = 1.0 / 100.0;
+        }
+        if (Math.random() < chance) {
+            int crystal = SKILLING_CRYSTALS.getOrDefault(skill, -1);
+            if (crystal > 0) {
+                player.getItems().addItem(crystal, 1);
+                player.sendMessage("@blu@You've found a shimmering Skilling Crystal!");
+                player.setCrystalsFoundThisHour(player.getCrystalsFoundThisHour() + 1);
+            }
+        }
+    }
+
+    /** Decrease durability of all augments on the tool after an action. */
+    public static void decrementDurability(Player player, int itemId) {
+        List<AugmentInstance> list = player.getToolAugments().get(itemId);
+        if (list == null) return;
+        for (AugmentInstance inst : list) {
+            if (!inst.isActive()) continue;
+            inst.degrade();
+            if (!inst.isActive()) {
+                player.sendMessage("Your " + inst.getAugment().getDescription() + " augment has depleted.");
+            }
+        }
+    }
+
+    /** Check for set bonuses like the Precision set. */
+    public static void checkSetBonuses(Player player) {
+        int focus = 0;
+        for (int id : player.playerEquipment) {
+            List<AugmentInstance> list = player.getToolAugments().get(id);
+            if (list == null) continue;
+            for (AugmentInstance inst : list) {
+                if (inst.isActive() && inst.getAugment() == ToolAugment.FOCUS) {
+                    focus++;
+                }
+            }
+        }
+        boolean active = focus >= 3;
+        if (active != player.isPrecisionSetActive()) {
+            player.setPrecisionSetActive(active);
+            if (active) {
+                player.sendMessage("@pur@Precision Set bonus active (+5% XP).");
+            } else {
+                player.sendMessage("Precision Set bonus no longer active.");
+            }
+        }
+    }
+
+}

--- a/src/io/xeros/model/entity/player/Player.java
+++ b/src/io/xeros/model/entity/player/Player.java
@@ -144,6 +144,8 @@ import io.xeros.content.tutorial.TutorialDialogue;
 import io.xeros.content.upgrade.UpgradeInterface;
 import io.xeros.content.vote_panel.VotePanelManager;
 import io.xeros.content.vote_panel.VoteUser;
+import io.xeros.content.tools.AugmentInstance;
+import io.xeros.content.tools.ToolAugment;
 import io.xeros.content.wilderness.ActiveVolcano;
 import io.xeros.content.wogw.WogwContributeInterface;
 import io.xeros.model.*;
@@ -638,6 +640,19 @@ public class Player extends Entity {
     private final MiniSmb miniSmb = new MiniSmb(this);
     private final MiniTobBox miniTobBox = new MiniTobBox(this);
     private final MiniUltraBox miniUltraBox = new MiniUltraBox(this);
+
+    // Tool augment system
+    private final Set<ToolAugment> unlockedToolAugments = new HashSet<>();
+    /** Tool id -> applied augments with rarity/durability. */
+    private final Map<Integer, List<AugmentInstance>> toolAugments = new HashMap<>();
+    /** Whether the precision set bonus is active. */
+    private boolean precisionSetActive;
+    /** Last 10 FoE burns. */
+    private final Deque<String> burnHistory = new ArrayDeque<>();
+    /** Last 10 tinker actions. */
+    private final Deque<String> tinkerLogs = new ArrayDeque<>();
+    private int crystalsFoundThisHour;
+    private long crystalHourStart;
 
     private final EntityDamageQueue entityDamageQueue = new EntityDamageQueue(this);
     private BountyHunter bountyHunter = new BountyHunter(this);
@@ -3546,6 +3561,50 @@ public class Player extends Entity {
 
     public EntityDamageQueue getDamageQueue() {
         return entityDamageQueue;
+    }
+
+    public Set<ToolAugment> getUnlockedToolAugments() {
+        return unlockedToolAugments;
+    }
+
+    public Map<Integer, List<AugmentInstance>> getToolAugments() {
+        return toolAugments;
+    }
+
+    public boolean isPrecisionSetActive() {
+        return precisionSetActive;
+    }
+
+    public void setPrecisionSetActive(boolean active) {
+        this.precisionSetActive = active;
+    }
+
+    public Deque<String> getBurnHistory() {
+        return burnHistory;
+    }
+
+    public Deque<String> getTinkerLogs() {
+        return tinkerLogs;
+    }
+
+    public int getCrystalsFoundThisHour() {
+        return crystalsFoundThisHour;
+    }
+
+    public void setCrystalsFoundThisHour(int crystalsFoundThisHour) {
+        this.crystalsFoundThisHour = crystalsFoundThisHour;
+    }
+
+    public long getCrystalHourStart() {
+        return crystalHourStart;
+    }
+
+    public void setCrystalHourStart(long crystalHourStart) {
+        this.crystalHourStart = crystalHourStart;
+    }
+
+    public boolean wearingFullSkillingOutfit() {
+        return false;
     }
 
     public long[] reduceSpellDelay = new long[6];

--- a/src/io/xeros/model/entity/player/packets/objectoptions/ObjectOptionOne.java
+++ b/src/io/xeros/model/entity/player/packets/objectoptions/ObjectOptionOne.java
@@ -36,6 +36,7 @@ import io.xeros.content.donor.DonoSlayerInstances;
 import io.xeros.content.donor.DonorVault;
 import io.xeros.content.event.eventcalendar.EventChallenge;
 import io.xeros.content.item.lootable.impl.*;
+import io.xeros.content.tools.ToolAugments;
 import io.xeros.content.leaderboards.LeaderboardInterface;
 import io.xeros.content.minigames.pest_control.PestControl;
 import io.xeros.content.minigames.pk_arena.Highpkarena;
@@ -928,6 +929,9 @@ public class ObjectOptionOne {
                 if (c.absY == 3494 || c.absY == 3495 || c.absY == 3496) {
                     AgilityHandler.delayEmote(c, "CLIMB_DOWN", c.getX(), c.getY(), c.getHeight() - 1, 2);
                 }
+                break;
+            case ToolAugments.TINKER_TABLE_ID:
+                c.sendMessage("Use a skilling tool on the table to manage augments.");
                 break;
             case 33311:
                 Hespori.burnEssence(c);

--- a/src/io/xeros/model/items/ItemAssistant.java
+++ b/src/io/xeros/model/items/ItemAssistant.java
@@ -40,6 +40,7 @@ import io.xeros.model.multiplayersession.duel.DuelSession;
 import io.xeros.model.multiplayersession.duel.DuelSessionRules;
 import io.xeros.model.shops.ShopAssistant;
 import io.xeros.util.Misc;
+import io.xeros.content.tools.ToolAugments;
 import org.apache.commons.lang3.RandomUtils;
 
 import java.util.*;
@@ -1661,15 +1662,16 @@ public class ItemAssistant {
 				player.updateGodItems();
 			}
 
-			player.getPA().sendSound(Sounds.getEquipItemSound(wearID));
-			this.addContainerUpdate(ContainerUpdate.EQUIPMENT);
-			this.addContainerUpdate(ContainerUpdate.INVENTORY);
-			sendEquipmentContainer();
-			return true;
-		} else {
-			return false;
-		}
-	}
+                        player.getPA().sendSound(Sounds.getEquipItemSound(wearID));
+                        this.addContainerUpdate(ContainerUpdate.EQUIPMENT);
+                        this.addContainerUpdate(ContainerUpdate.INVENTORY);
+                        sendEquipmentContainer();
+                        ToolAugments.onEquip(player, wearID);
+                        return true;
+                } else {
+                        return false;
+                }
+        }
 
 	/**
 	 * Indicates the action to wear an item.


### PR DESCRIPTION
## Summary
- Add Basic/Enhanced/Masterwork augment tiers powered by skilling crystals
- Upgrade or remove tool augments at the Tinker Table with crystal costs and logging
- Drop and earn skilling crystals through skilling actions and Fire of Exchange burns

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68941fca26d88320ba96bb05bd4741db