### PR TITLE
Add environmental hazards and mutator system to AOE instances

### DIFF
--- a/resources/aoe_environmental_hazards.json
+++ b/resources/aoe_environmental_hazards.json
@@ -1,0 +1,52 @@
+{
+  "TIER1": {"frequency": 50, "hazards": [
+    {"type": "FIRE_TILE", "damage": 2, "duration": 5, "triggerCondition": "PRAYER_USED", "cooldownWindow": 5000},
+    {"type": "POISON_MIST", "drain": 1, "duration": 5, "triggerCondition": "HEAL_BIG", "cooldownWindow": 8000},
+    {"type": "CRUMBLING_FLOOR", "stun": 5, "duration": 10}
+  ]},
+  "TIER2": {"frequency": 48, "hazards": [
+    {"type": "FIRE_TILE", "damage": 3, "duration": 5},
+    {"type": "POISON_MIST", "drain": 1, "duration": 6},
+    {"type": "CRUMBLING_FLOOR", "stun": 6, "duration": 10}
+  ]},
+  "TIER3": {"frequency": 46, "hazards": [
+    {"type": "FIRE_TILE", "damage": 4, "duration": 5},
+    {"type": "POISON_MIST", "drain": 2, "duration": 6},
+    {"type": "CRUMBLING_FLOOR", "stun": 6, "duration": 10}
+  ]},
+  "TIER4": {"frequency": 44, "hazards": [
+    {"type": "FIRE_TILE", "damage": 5, "duration": 6},
+    {"type": "POISON_MIST", "drain": 2, "duration": 6},
+    {"type": "CRUMBLING_FLOOR", "stun": 7, "duration": 11}
+  ]},
+  "TIER5": {"frequency": 42, "hazards": [
+    {"type": "FIRE_TILE", "damage": 6, "duration": 6},
+    {"type": "POISON_MIST", "drain": 2, "duration": 6},
+    {"type": "CRUMBLING_FLOOR", "stun": 8, "duration": 11}
+  ]},
+  "TIER6": {"frequency": 40, "hazards": [
+    {"type": "FIRE_TILE", "damage": 7, "duration": 6},
+    {"type": "POISON_MIST", "drain": 3, "duration": 7},
+    {"type": "CRUMBLING_FLOOR", "stun": 9, "duration": 11}
+  ]},
+  "TIER7": {"frequency": 38, "hazards": [
+    {"type": "FIRE_TILE", "damage": 7, "duration": 6},
+    {"type": "POISON_MIST", "drain": 3, "duration": 7},
+    {"type": "CRUMBLING_FLOOR", "stun": 9, "duration": 12}
+  ]},
+  "TIER8": {"frequency": 36, "hazards": [
+    {"type": "FIRE_TILE", "damage": 8, "duration": 6},
+    {"type": "POISON_MIST", "drain": 3, "duration": 7},
+    {"type": "CRUMBLING_FLOOR", "stun": 10, "duration": 12}
+  ]},
+  "TIER9": {"frequency": 34, "hazards": [
+    {"type": "FIRE_TILE", "damage": 9, "duration": 7},
+    {"type": "POISON_MIST", "drain": 4, "duration": 7},
+    {"type": "CRUMBLING_FLOOR", "stun": 11, "duration": 12}
+  ]},
+  "TIER10": {"frequency": 30, "hazards": [
+    {"type": "FIRE_TILE", "damage": 10, "duration": 7},
+    {"type": "POISON_MIST", "drain": 4, "duration": 7},
+    {"type": "CRUMBLING_FLOOR", "stun": 12, "duration": 12}
+  ]}
+}

--- a/resources/aoe_environmental_patterns.json
+++ b/resources/aoe_environmental_patterns.json
@@ -1,0 +1,10 @@
+{
+  "TIER_1": {
+    "frequency": 50,
+    "patterns": [
+      { "type": "FLAME_RING" },
+      { "type": "VOID_PULSE" },
+      { "type": "TOXIC_TORRENT" }
+    ]
+  }
+}

--- a/resources/aoe_mutator_synergies.json
+++ b/resources/aoe_mutator_synergies.json
@@ -1,0 +1,6 @@
+[
+  {
+    "mutators": ["DOUBLE_HAZARD_MODE", "UNSTABLE_TILES"],
+    "name": "Hazard Spiral"
+  }
+]

--- a/resources/aoe_mutators.json
+++ b/resources/aoe_mutators.json
@@ -1,0 +1,8 @@
+{
+  "DOUBLE_HAZARD_MODE": {"rarity": "COMMON"},
+  "NO_PRAYER_RECOVERY": {"rarity": "UNCOMMON"},
+  "RANDOM_BOSS_PHASE_SHIFT": {"rarity": "RARE"},
+  "UNSTABLE_TILES": {"rarity": "UNCOMMON"},
+  "VENOMOUS": {"rarity": "UNCOMMON"},
+  "ANOMALY": {"rarity": "LEGENDARY"}
+}

--- a/resources/aoe_weekly_hazards.json
+++ b/resources/aoe_weekly_hazards.json
@@ -1,0 +1,5 @@
+{
+  "staticHazards": ["FIRE_TILE", "POISON_MIST", "CRUMBLING_FLOOR"],
+  "synergyMutators": ["VENOMOUS", "UNSTABLE_TILES"],
+  "eliteHazard": "FIRE_TILE"
+}

--- a/resources/boss_instance_special_attacks.json
+++ b/resources/boss_instance_special_attacks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "infernal_slam",
+    "activationChance": 0.2,
+    "cooldown": 12,
+    "animation": 7004,
+    "gfx": 78,
+    "sound": 123,
+    "effect": "INFERNAL_SLAM",
+    "messages": ["The demon slams the ground, scorching flames erupt!"]
+  }
+]

--- a/resources/instance_rewards.json
+++ b/resources/instance_rewards.json
@@ -1,0 +1,17 @@
+{
+  "bronze": [
+    {"id": 995, "amount": 1000}
+  ],
+  "silver": [
+    {"id": 995, "amount": 5000}
+  ],
+  "gold": [
+    {"id": 995, "amount": 10000}
+  ],
+  "platinum": [
+    {"id": 995, "amount": 20000}
+  ],
+  "diamond": [
+    {"id": 995, "amount": 50000}
+  ]
+}

--- a/src/io/xeros/content/combat/core/AttackEntity.java
+++ b/src/io/xeros/content/combat/core/AttackEntity.java
@@ -31,6 +31,7 @@ import io.xeros.model.entity.EntityReference;
 import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.npc.NPCClipping;
 import io.xeros.model.entity.npc.NPCHandler;
+import io.xeros.content.instances.BossInstanceManager;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.PlayerHandler;
@@ -339,9 +340,12 @@ public class AttackEntity {
                 }
             }
             //  return;
-        } else if (Boundary.isIn(attacker, Boundary.AOEInstance) && aoeData == null) {
-            attacker.sendMessage("You cannot use this weapon inside the instance!");
-            return;
+        } else {
+            BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(attacker);
+            if (area != null && area.isWithinAoeZone(attacker.getPosition()) && aoeData == null) {
+                attacker.sendMessage("You cannot use this weapon inside the instance!");
+                return;
+            }
         }
 
         if (getCombatType() == CombatType.MAGE && !MagicRequirements.checkMagicReqs(attacker, attacker.getSpellId(),

--- a/src/io/xeros/content/combat/death/NPCDeath.java
+++ b/src/io/xeros/content/combat/death/NPCDeath.java
@@ -43,6 +43,7 @@ import io.xeros.model.items.EquipmentSet;
 import io.xeros.model.items.GameItem;
 import io.xeros.util.Location3D;
 import io.xeros.util.Misc;
+import io.xeros.content.instances.InstanceMutatorManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -368,6 +369,7 @@ public class NPCDeath {
                 }
             }
             BossInstanceOverlayManager.sendKillOverlay(player);
+            InstanceMutatorManager.spikeGlobal(5);
         }
 
         if (NpcDef.forId(npcId).getCombatLevel() >= 1) {

--- a/src/io/xeros/content/combat/melee/CombatPrayer.java
+++ b/src/io/xeros/content/combat/melee/CombatPrayer.java
@@ -12,6 +12,7 @@ import io.xeros.model.multiplayersession.MultiplayerSessionStage;
 import io.xeros.model.multiplayersession.MultiplayerSessionType;
 import io.xeros.model.multiplayersession.duel.DuelSession;
 import io.xeros.model.multiplayersession.duel.DuelSessionRules;
+import io.xeros.content.instances.BossInstanceManager;
 
 import java.util.Arrays;
 import java.util.List;
@@ -334,9 +335,13 @@ public class CombatPrayer {
 		activatePrayer(c, i, true);
 	}
 
-	private static void activatePrayer(Player c, int i, boolean shift) {
-		// Shift prayers right
-		if (shift && c.isProtectionPrayersShiftRight()) {
+    private static void activatePrayer(Player c, int i, boolean shift) {
+        BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(c);
+        if (area != null) {
+            area.getHazardScheduler().trigger("PRAYER_USED", c);
+        }
+        // Shift prayers right
+        if (shift && c.isProtectionPrayersShiftRight()) {
 			if (i == 18) {
 				i = 16;
 			} else if (i == 17) {

--- a/src/io/xeros/content/commands/admin/Dangerlevel.java
+++ b/src/io/xeros/content/commands/admin/Dangerlevel.java
@@ -1,0 +1,31 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.InstanceMutatorManager;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Displays current local and global danger meters. */
+public class Dangerlevel extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        // zone id currently unused but kept for compatibility
+        c.sendMessage("Danger: " + InstanceMutatorManager.getDangerLevel() + "/100, global: " + InstanceMutatorManager.getGlobalDanger() + "/100");
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("show danger meter");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Debughazards.java
+++ b/src/io/xeros/content/commands/admin/Debughazards.java
@@ -1,0 +1,60 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+import io.xeros.util.Misc;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
+
+/** Prints active hazard information for a zone. */
+public class Debughazards extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 1 || parts[0].isEmpty()) {
+            c.sendMessage("Usage: ::debughazards <zoneId>");
+            return;
+        }
+        int zoneId;
+        try {
+            zoneId = Integer.parseInt(parts[0]);
+        } catch (NumberFormatException e) {
+            zoneId = -1;
+        }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        String time = new SimpleDateFormat("HH:mm:ss").format(new Date());
+        for (String line : area.getHazardScheduler().debugState()) {
+            c.sendMessage(line);
+            Misc.println("[" + time + "] " + line);
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("debug active hazards");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Debugmutators.java
+++ b/src/io/xeros/content/commands/admin/Debugmutators.java
@@ -1,0 +1,45 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.InstanceMutator;
+import io.xeros.content.instances.InstanceMutatorManager;
+import io.xeros.content.instances.MutatorRarity;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+import io.xeros.util.Misc;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+/** Lists active mutators and synergy modifiers. */
+public class Debugmutators extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String time = new SimpleDateFormat("HH:mm:ss").format(new Date());
+        for (InstanceMutator mut : InstanceMutatorManager.getActiveMutators()) {
+            MutatorRarity rarity = InstanceMutatorManager.getRarity(mut);
+            c.sendMessage(mut.name() + " (" + rarity + ")");
+            Misc.println("[" + time + "] " + mut.name() + " (" + rarity + ")");
+            List<?> mods = InstanceMutatorManager.getHazardSynergies(mut);
+            for (Object obj : mods) {
+                c.sendMessage(" - " + obj.toString());
+            }
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("debug mutators");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Debugnpcreactions.java
+++ b/src/io/xeros/content/commands/admin/Debugnpcreactions.java
@@ -1,0 +1,56 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.content.instances.hazard.HazardDebugLogger;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Displays recent hazard reaction callbacks from NPCs. */
+public class Debugnpcreactions extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 1 || parts[0].isEmpty()) {
+            c.sendMessage("Usage: ::debugnpcreactions <zoneId>");
+            return;
+        }
+        int zoneId;
+        try {
+            zoneId = Integer.parseInt(parts[0]);
+        } catch (NumberFormatException e) {
+            zoneId = -1;
+        }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        for (String log : HazardDebugLogger.getNpcLogs(area)) {
+            c.sendMessage(log);
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("debug npc hazard reactions");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Hazardaudit.java
+++ b/src/io/xeros/content/commands/admin/Hazardaudit.java
@@ -1,0 +1,52 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.content.instances.hazard.HazardDebugLogger;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Dumps hazard events for a zone to the chat box. */
+public class Hazardaudit extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 1) {
+            c.sendMessage("Usage: ::hazardaudit <zoneId>");
+            return;
+        }
+        int zoneId;
+        try { zoneId = Integer.parseInt(parts[0]); } catch (NumberFormatException e) { zoneId = -1; }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        for (String line : HazardDebugLogger.getAuditLogs(area)) {
+            c.sendMessage(line);
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("display hazard audit log");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Hazardlogdump.java
+++ b/src/io/xeros/content/commands/admin/Hazardlogdump.java
@@ -1,0 +1,57 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.content.instances.hazard.HazardDebugLogger;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/** Writes the hazard audit log to a file on disk. */
+public class Hazardlogdump extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 1) {
+            c.sendMessage("Usage: ::hazardlogdump <zoneId>");
+            return;
+        }
+        int zoneId;
+        try { zoneId = Integer.parseInt(parts[0]); } catch (NumberFormatException e) { zoneId = -1; }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        try {
+            Path path = Path.of("hazard_log_zone" + zoneId + ".txt");
+            HazardDebugLogger.dump(area, path);
+            c.sendMessage("Wrote log to " + path.toAbsolutePath());
+        } catch (Exception e) {
+            c.sendMessage("Failed to write log: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("dump hazard log to file");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Hazardstatus.java
+++ b/src/io/xeros/content/commands/admin/Hazardstatus.java
@@ -1,0 +1,56 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+import io.xeros.util.Misc;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
+
+/** Outputs live hazard state in an instance. */
+public class Hazardstatus extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 1 || parts[0].isEmpty()) {
+            c.sendMessage("Usage: ::hazardstatus <zoneId>");
+            return;
+        }
+        int zoneId;
+        try { zoneId = Integer.parseInt(parts[0]); } catch (NumberFormatException e) { zoneId = -1; }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        String time = new SimpleDateFormat("HH:mm:ss").format(new Date());
+        for (String line : area.getHazardScheduler().debugState()) {
+            c.sendMessage(line);
+            Misc.println("[" + time + "] " + line);
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("debug hazard status");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Hazardvision.java
+++ b/src/io/xeros/content/commands/admin/Hazardvision.java
@@ -1,0 +1,31 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Toggles developer hazard tile overlays. */
+public class Hazardvision extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        boolean enabled = !c.getAttributes().getBoolean("hazardvision");
+        c.getAttributes().set("hazardvision", enabled);
+        c.sendMessage("Hazard vision " + (enabled ? "enabled" : "disabled") + ".");
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("toggle hazard overlays");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Mutatorvision.java
+++ b/src/io/xeros/content/commands/admin/Mutatorvision.java
@@ -1,0 +1,31 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Toggles developer mutator overlays. */
+public class Mutatorvision extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        boolean enabled = !c.getAttributes().getBoolean("mutatorvision");
+        c.getAttributes().set("mutatorvision", enabled);
+        c.sendMessage("Mutator vision " + (enabled ? "enabled" : "disabled") + ".");
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("toggle mutator overlays");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Reloadaoezone.java
+++ b/src/io/xeros/content/commands/admin/Reloadaoezone.java
@@ -1,0 +1,56 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.content.instances.InstanceMutatorManager;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Reloads NPCs, mutators and hazards for a zone. */
+public class Reloadaoezone extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 1 || parts[0].isEmpty()) {
+            c.sendMessage("Usage: ::reloadaoezone <zoneId>");
+            return;
+        }
+        int zoneId;
+        try {
+            zoneId = Integer.parseInt(parts[0]);
+        } catch (NumberFormatException e) {
+            zoneId = -1;
+        }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        BossInstanceManager.reloadArea(area);
+        InstanceMutatorManager.rollWeeklyMutators();
+        c.sendMessage("AOE zone reloaded.");
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("reload aoe zone");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Reloadhazards.java
+++ b/src/io/xeros/content/commands/admin/Reloadhazards.java
@@ -1,0 +1,27 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.hazard.WeeklyHazardManager;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Reloads weekly hazard configuration from disk. */
+public class Reloadhazards extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        WeeklyHazardManager.reload();
+        c.sendMessage("Hazard configuration reloaded.");
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("reload weekly hazards");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Replayhazard.java
+++ b/src/io/xeros/content/commands/admin/Replayhazard.java
@@ -1,0 +1,56 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.content.instances.hazard.EnvironmentalHazardType;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Replays the last triggered hazard of a given type. */
+public class Replayhazard extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 2) {
+            c.sendMessage("Usage: ::replayhazard <zoneId> <hazardType>");
+            return;
+        }
+        int zoneId;
+        try { zoneId = Integer.parseInt(parts[0]); } catch (NumberFormatException e) { zoneId = -1; }
+        EnvironmentalHazardType type;
+        try { type = EnvironmentalHazardType.valueOf(parts[1].toUpperCase()); } catch (Exception e) { c.sendMessage("Unknown type."); return; }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        if (area.getHazardScheduler().replay(type)) {
+            c.sendMessage("Replayed hazard " + type + ".");
+        } else {
+            c.sendMessage("No hazard recorded for " + type + ".");
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("replay last hazard");
+    }
+}

--- a/src/io/xeros/content/commands/admin/Spawnhazard.java
+++ b/src/io/xeros/content/commands/admin/Spawnhazard.java
@@ -1,0 +1,71 @@
+package io.xeros.content.commands.admin;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import io.xeros.content.instances.hazard.EnvironmentalHazardPattern;
+import io.xeros.content.instances.hazard.EnvironmentalHazardPattern.PatternType;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/** Spawns a hazard pattern immediately for testing. */
+public class Spawnhazard extends Command {
+    @Override
+    public void execute(Player c, String commandName, String input) {
+        if (!hasPrivilege(c)) {
+            c.sendMessage("This command is for admins only.");
+            return;
+        }
+        String[] parts = input.split(" ");
+        if (parts.length < 3) {
+            c.sendMessage("Usage: ::spawnhazard <zoneId> <hazardType> <tier>");
+            return;
+        }
+        int zoneId;
+        try {
+            zoneId = Integer.parseInt(parts[0]);
+        } catch (NumberFormatException e) {
+            zoneId = -1;
+        }
+        int dummyTier;
+        try {
+            dummyTier = Integer.parseInt(parts[2]);
+        } catch (NumberFormatException e) {
+            dummyTier = 1;
+        }
+        PatternType type;
+        try {
+            type = PatternType.valueOf(parts[1].toUpperCase());
+        } catch (Exception e) {
+            c.sendMessage("Unknown hazard type.");
+            return;
+        }
+        BossTier[] tiers = BossTier.values();
+        if (zoneId < 1 || zoneId > tiers.length) {
+            c.sendMessage("Invalid zone id.");
+            return;
+        }
+        BossInstanceArea area = BossInstanceManager.getAny(tiers[zoneId - 1]);
+        if (area == null) {
+            c.sendMessage("No active instance for that tier.");
+            return;
+        }
+        EnvironmentalHazardPattern pattern = new EnvironmentalHazardPattern();
+        pattern.setType(type);
+        pattern.activate(area);
+        c.sendMessage("Spawned hazard " + type + ".");
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return Right.ADMINISTRATOR.isOrInherits(player);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("spawn hazard pattern");
+    }
+}

--- a/src/io/xeros/content/commands/all/Instancehistory.java
+++ b/src/io/xeros/content/commands/all/Instancehistory.java
@@ -1,0 +1,36 @@
+package io.xeros.content.commands.all;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.model.entity.player.Player;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Displays the player's best instance times and scores.
+ */
+public class Instancehistory extends Command {
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        player.sendMessage("@blu@Instance history:");
+        for (BossInstanceManager.BossTier tier : BossInstanceManager.BossTier.values()) {
+            Integer score = player.getBestInstanceScores().get(tier);
+            Long time = player.getBestInstanceTimes().get(tier);
+            if (score != null && time != null) {
+                long seconds = TimeUnit.MILLISECONDS.toSeconds(time);
+                player.sendMessage(tier.getZoneName() + " - Score: " + score + ", Time: " + seconds + "s");
+            }
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("Shows instance performance history.");
+    }
+}

--- a/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
@@ -117,7 +117,7 @@ public class BossInstanceDialogue extends DialogueBuilder {
         StringBuilder label = new StringBuilder(BossInstanceManager.getTierDisplayNameSafe(tier, player));
 
         // Append up to three key drop names
-        List<GameItem> drops = Server.getDropManager().getNPCdrops(tier.getKillNpcId());
+        List<GameItem> drops = Server.getDropManager().getNPCdrops(tier.getBossNpcId());
         if (drops != null && !drops.isEmpty()) {
             String dropNames = drops.stream()
                     .limit(3)

--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -4,14 +4,18 @@ import io.xeros.content.instances.impl.LegacySoloPlayerInstance;
 import io.xeros.model.Npcs;
 import io.xeros.model.definitions.NpcDef;
 import io.xeros.model.definitions.NpcStats;
+import io.xeros.model.definitions.NpcStatsBuilder;
 import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.npc.NPCSpawning;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
 import io.xeros.util.Misc;
+import io.xeros.model.cycleevent.CycleEvent;
+import io.xeros.model.cycleevent.CycleEventContainer;
+import io.xeros.model.cycleevent.CycleEventHandler;
 
-import java.util.Arrays;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -23,6 +27,10 @@ public class BossInstanceManager {
     /** Tracks active instances keyed by owning player. */
     private static final Map<Player, BossInstanceArea> INSTANCES = new ConcurrentHashMap<>();
 
+    /** Minimum distance an NPC must be from the player spawn to still
+     *  automatically aggro. This can be tweaked for balancing. */
+    private static final int MINIMUM_AGGRO_RANGE = 8;
+
     /**
      * Instance wrapper that automatically removes itself from the instance map
      * when disposed so height levels are immediately reusable.
@@ -30,20 +38,56 @@ public class BossInstanceManager {
     public static class BossInstanceArea extends LegacySoloPlayerInstance {
         private final Player owner;
         private final BossTier tier;
+        private final io.xeros.content.instances.hazard.EnvironmentalHazardScheduler hazards;
+        private final boolean dynamicWaveScaling;
 
         BossInstanceArea(Player owner, BossTier tier, Boundary boundary) {
-            super(InstanceConfiguration.CLOSE_ON_EMPTY, owner, boundary);
+            super(InstanceConfiguration.CLOSE_ON_EMPTY_RESPAWN, owner, boundary);
             this.owner = owner;
             this.tier = tier;
+            this.hazards = new io.xeros.content.instances.hazard.EnvironmentalHazardScheduler(this);
+            this.dynamicWaveScaling = tier.isDynamicWaveScaling();
         }
 
         @Override
         public void onDispose() {
+            hazards.stop();
             INSTANCES.remove(owner);
+        }
+
+        public void startHazards() {
+            hazards.start();
+        }
+
+        public void startDynamicSpawns() {
+            if (!dynamicWaveScaling) {
+                return;
+            }
+            CycleEventHandler.getSingleton().addEvent(this, new CycleEvent() {
+                int ticks;
+                @Override
+                public void execute(CycleEventContainer container) {
+                    ticks++;
+                    if (ticks % 50 == 0) {
+                        spawnInstanceGrid(owner, tier, BossInstanceArea.this, false);
+                    }
+                    if (InstanceMutatorManager.getGlobalDanger() > 90) {
+                        spawnInstanceGrid(owner, tier, BossInstanceArea.this, false);
+                    }
+                }
+            }, 1);
         }
 
         public BossTier getTier() {
             return tier;
+        }
+
+        public boolean isWithinAoeZone(Position pos) {
+            return tier.getZoneBoundary().inside(pos);
+        }
+
+        public io.xeros.content.instances.hazard.EnvironmentalHazardScheduler getHazardScheduler() {
+            return hazards;
         }
     }
 
@@ -53,12 +97,16 @@ public class BossInstanceManager {
         private final int hitpoints;
         private final int attack;
         private final int defence;
+        private final int count;
+        private final List<String> specialAttacks;
 
-        public BossMob(int npcId, int hitpoints, int attack, int defence) {
+        public BossMob(int npcId, int hitpoints, int attack, int defence, int count, List<String> specialAttacks) {
             this.npcId = npcId;
             this.hitpoints = hitpoints;
             this.attack = attack;
             this.defence = defence;
+            this.count = count;
+            this.specialAttacks = specialAttacks;
         }
 
         public int getNpcId() {
@@ -76,6 +124,14 @@ public class BossInstanceManager {
         public int getDefence() {
             return defence;
         }
+
+        public int getCount() { 
+            return count;
+        }
+
+        public List<String> getSpecialAttacks() {
+            return specialAttacks;
+        }
     }
 
     /**
@@ -83,26 +139,36 @@ public class BossInstanceManager {
      * the NPCs that can spawn.
      */
     public enum BossTier {
-        TIER1("Training Grounds", 0, 0, -1, 5, Npcs.COW,
-                new BossMob[]{new BossMob(Npcs.COW, 10, 1, 1)}),
-        TIER2("Goblin Camp", 25, 10_000, -1, 10, Npcs.GOBLIN,
-                new BossMob[]{new BossMob(Npcs.GOBLIN, 15, 5, 5)}),
-        TIER3("Giants' Den", 75, 100_000, -1, 20, Npcs.HILL_GIANT,
-                new BossMob[]{new BossMob(Npcs.HILL_GIANT, 35, 20, 20)}),
-        TIER4("Moss Cave", 150, 250_000, -1, 25, Npcs.MOSS_GIANT,
-                new BossMob[]{new BossMob(Npcs.MOSS_GIANT, 60, 40, 40)}),
-        TIER5("Fire Pit", 250, 500_000, -1, 30, Npcs.FIRE_GIANT,
-                new BossMob[]{new BossMob(Npcs.FIRE_GIANT, 80, 60, 60)}),
-        TIER6("Green Dragons", 350, 750_000, -1, 35, Npcs.GREEN_DRAGON,
-                new BossMob[]{new BossMob(Npcs.GREEN_DRAGON, 120, 90, 90)}),
-        TIER7("Red Dragons", 500, 1_000_000, -1, 40, Npcs.RED_DRAGON,
-                new BossMob[]{new BossMob(Npcs.RED_DRAGON, 150, 110, 110)}),
-        TIER8("Black Dragons", 650, 2_000_000, -1, 45, Npcs.BLACK_DRAGON,
-                new BossMob[]{new BossMob(Npcs.BLACK_DRAGON, 180, 130, 130)}),
-        TIER9("Demon Domain", 800, 3_000_000, -1, 50, Npcs.BLACK_DEMON,
-                new BossMob[]{new BossMob(Npcs.BLACK_DEMON, 200, 150, 150)}),
-        TIER10("Dragon King", 1_000, 5_000_000, 11286, 60, Npcs.KING_BLACK_DRAGON,
-                new BossMob[]{new BossMob(Npcs.KING_BLACK_DRAGON, 250, 180, 180)});
+        TIER1("Training Grounds", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 0, 0, -1, 5, Npcs.COW, 20,
+                new BossMob[]{new BossMob(Npcs.COW, 10, 1, 1, 5, List.of())},
+                new TierCombatProfile(1.0,1.0,1.0,1.0,1.0,List.of())),
+        TIER2("Goblin Camp", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 25, 10_000, -1, 10, Npcs.GOBLIN, 20,
+                new BossMob[]{new BossMob(Npcs.GOBLIN, 15, 5, 5, 5, List.of())},
+                new TierCombatProfile(1.1,1.05,1.05,1.05,1.0,List.of())),
+        TIER3("Giants' Den", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 75, 100_000, -1, 20, Npcs.HILL_GIANT, 20,
+                new BossMob[]{new BossMob(Npcs.HILL_GIANT, 35, 20, 20, 6, List.of())},
+                new TierCombatProfile(1.2,1.1,1.1,1.1,1.05,List.of())),
+        TIER4("Moss Cave", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 150, 250_000, -1, 25, Npcs.MOSS_GIANT, 20,
+                new BossMob[]{new BossMob(Npcs.MOSS_GIANT, 60, 40, 40, 6, List.of())},
+                new TierCombatProfile(1.3,1.15,1.15,1.15,1.1,List.of())),
+        TIER5("Fire Pit", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 250, 500_000, -1, 30, Npcs.FIRE_GIANT, 20,
+                new BossMob[]{new BossMob(Npcs.FIRE_GIANT, 80, 60, 60, 7, List.of())},
+                new TierCombatProfile(1.4,1.2,1.2,1.2,1.15,List.of())),
+        TIER6("Green Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 350, 750_000, -1, 35, Npcs.GREEN_DRAGON, 20,
+                new BossMob[]{new BossMob(Npcs.GREEN_DRAGON, 120, 90, 90, 7, List.of())},
+                new TierCombatProfile(1.5,1.25,1.25,1.25,1.2,List.of())),
+        TIER7("Red Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 500, 1_000_000, -1, 40, Npcs.RED_DRAGON, 20,
+                new BossMob[]{new BossMob(Npcs.RED_DRAGON, 150, 110, 110, 8, List.of())},
+                new TierCombatProfile(1.6,1.3,1.3,1.3,1.25,List.of())),
+        TIER8("Black Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 650, 2_000_000, -1, 45, Npcs.BLACK_DRAGON, 20,
+                new BossMob[]{new BossMob(Npcs.BLACK_DRAGON, 180, 130, 130, 8, List.of())},
+                new TierCombatProfile(1.7,1.35,1.35,1.35,1.3,List.of())),
+        TIER9("Demon Domain", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 800, 3_000_000, -1, 50, Npcs.BLACK_DEMON, 20,
+                new BossMob[]{new BossMob(Npcs.BLACK_DEMON, 200, 150, 150, 9, List.of("infernal_slam"))},
+                new TierCombatProfile(1.8,1.4,1.4,1.4,1.35,List.of("infernal_slam"))),
+        TIER10("Dragon King", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 1_000, 5_000_000, 11286, 60, Npcs.KING_BLACK_DRAGON, 20,
+                new BossMob[]{new BossMob(Npcs.KING_BLACK_DRAGON, 250, 180, 180, 1, List.of("infernal_slam"))},
+                new TierCombatProfile(2.0,1.5,1.5,1.45,1.4,List.of("infernal_slam")));
 
         static {
             TIER1.requiredKillCountToUnlockNext = 25;  TIER1.nextTier = TIER2;
@@ -118,28 +184,53 @@ public class BossInstanceManager {
         }
 
         private final String zoneName;
+        private final Boundary zoneBoundary;
+        private final Position spawnTile;
         private final int killRequirement;
         private final int gpCost;
         private final int itemRequirement;
         private final int respawnTime;
-        private final int killNpcId;
+        private final int bossNpcId;
+        private final int desiredNpcDensity;
         private final BossMob[] mobs;
+        private final TierCombatProfile combatProfile;
+        private final boolean dynamicWaveScaling;
         private int requiredKillCountToUnlockNext;
         private BossTier nextTier;
 
-        BossTier(String zoneName, int killRequirement, int gpCost, int itemRequirement,
-                 int respawnTime, int killNpcId, BossMob[] mobs) {
+        BossTier(String zoneName, Boundary zoneBoundary, Position spawnTile, int killRequirement, int gpCost, int itemRequirement,
+                 int respawnTime, int bossNpcId, int desiredNpcDensity, BossMob[] mobs, TierCombatProfile combatProfile) {
+            this(zoneName, zoneBoundary, spawnTile, killRequirement, gpCost, itemRequirement, respawnTime, bossNpcId,
+                    desiredNpcDensity, mobs, combatProfile, false);
+        }
+
+        BossTier(String zoneName, Boundary zoneBoundary, Position spawnTile, int killRequirement, int gpCost, int itemRequirement,
+                 int respawnTime, int bossNpcId, int desiredNpcDensity, BossMob[] mobs, TierCombatProfile combatProfile,
+                 boolean dynamicWaveScaling) {
             this.zoneName = zoneName;
+            this.zoneBoundary = zoneBoundary;
+            this.spawnTile = spawnTile;
             this.killRequirement = killRequirement;
             this.gpCost = gpCost;
             this.itemRequirement = itemRequirement;
             this.respawnTime = respawnTime;
-            this.killNpcId = killNpcId;
+            this.bossNpcId = bossNpcId;
+            this.desiredNpcDensity = desiredNpcDensity;
             this.mobs = mobs;
+            this.combatProfile = combatProfile;
+            this.dynamicWaveScaling = dynamicWaveScaling;
         }
 
         public String getZoneName() {
             return zoneName;
+        }
+
+        public Boundary getZoneBoundary() {
+            return zoneBoundary;
+        }
+
+        public Position getSpawnTile() {
+            return spawnTile;
         }
 
         public int getKillRequirement() {
@@ -158,13 +249,21 @@ public class BossInstanceManager {
             return respawnTime;
         }
 
-        public int getKillNpcId() {
-            return killNpcId;
+        public int getBossNpcId() {
+            return bossNpcId;
+        }
+
+        public int getDesiredNpcDensity() {
+            return desiredNpcDensity;
         }
 
         public BossMob[] getMobs() {
             return mobs;
         }
+
+        public TierCombatProfile getCombatProfile() { return combatProfile; }
+
+        public boolean isDynamicWaveScaling() { return dynamicWaveScaling; }
 
         public int getRequiredKillCountToUnlockNext() {
             return requiredKillCountToUnlockNext;
@@ -176,7 +275,7 @@ public class BossInstanceManager {
 
         /** Returns the player's kill count for the NPC associated with this tier. */
         public int getKillCount(Player player) {
-            String name = NpcDef.forId(killNpcId).getName();
+            String name = NpcDef.forId(bossNpcId).getName();
             return player.getNpcDeathTracker().getKc(name);
         }
     }
@@ -195,16 +294,21 @@ public class BossInstanceManager {
             return;
         }
 
-        Boundary bounds = new Boundary(player.getX() - 10, player.getY() - 10,
-                player.getX() + 10, player.getY() + 10);
+        Boundary bounds = tier.getZoneBoundary();
         BossInstanceArea area = new BossInstanceArea(player, tier, bounds);
         INSTANCES.put(player, area);
 
         area.add(player);
-        player.getPA().movePlayerUnconditionally(player.getX(), player.getY(), area.getHeight());
+        Position spawn = tier.getSpawnTile();
+        player.getPA().movePlayerUnconditionally(spawn.getX(), spawn.getY(), area.getHeight());
 
         spawnInstanceGrid(player, tier, area, false);
+        player.getInstancePerformanceTracker().start(tier);
         BossInstanceOverlayManager.sendKillOverlay(player);
+        area.startHazards();
+        area.startDynamicSpawns();
+        InstanceMutatorManager.resetDanger();
+        player.sendMessage("Active mutators: " + InstanceMutatorManager.getActiveDisplay());
     }
 
     /**
@@ -217,57 +321,100 @@ public class BossInstanceManager {
             return;
         }
 
-        Boundary bounds = new Boundary(player.getX() - 10, player.getY() - 10,
-                player.getX() + 10, player.getY() + 10);
+        Boundary bounds = tier.getZoneBoundary();
         BossInstanceArea area = new BossInstanceArea(player, tier, bounds);
         INSTANCES.put(player, area);
 
         area.add(player);
-        player.getPA().movePlayerUnconditionally(player.getX(), player.getY(), area.getHeight());
+        Position spawn = tier.getSpawnTile();
+        player.getPA().movePlayerUnconditionally(spawn.getX(), spawn.getY(), area.getHeight());
 
         spawnInstanceGrid(player, tier, area, true);
         player.setPreviewingBossInstance(true);
         BossInstanceOverlayManager.sendKillOverlay(player);
+        area.startDynamicSpawns();
+        InstanceMutatorManager.resetDanger();
+        player.sendMessage("Active mutators: " + InstanceMutatorManager.getActiveDisplay());
     }
 
     /**
-     * Spawns NPCs in a grid around the player so the instance feels populated.
-     * NPCs are spaced two tiles apart and up to twenty are spawned from the tier
-     * mob pool.
+     * Spawns NPCs randomly inside the tier's boundary so the instance feels populated.
+     * Each {@link BossMob} defines how many creatures should appear for the tier.
      */
     private static void spawnInstanceGrid(Player player, BossTier tier, BossInstanceArea area, boolean preview) {
-        int baseX = player.getX();
-        int baseY = player.getY();
+        Boundary bounds = tier.getZoneBoundary();
         int height = area.getHeight();
 
+        TierCombatProfile profile = tier.getCombatProfile();
         BossMob[] mobs = tier.getMobs();
         if (mobs.length == 0) {
             return;
         }
 
-        int spawned = 0;
-        for (int dx = -5; dx <= 5 && spawned < 20; dx += 2) {
-            for (int dy = -5; dy <= 5 && spawned < 20; dy += 2) {
-                BossMob mob = mobs[Misc.random(mobs.length - 1)];
-                NPC npc = NPCSpawning.spawnNpc(player, mob.getNpcId(), baseX + dx, baseY + dy,
-                        height, 0, 0, false, false,
-                        NpcStats.builder()
-                                .setHitpoints(mob.getHitpoints())
-                                .setAttackLevel(mob.getAttack())
-                                .setDefenceLevel(mob.getDefence())
-                                .createNpcStats());
-                if (npc != null) {
-                    if (preview) {
-                        npc.getBehaviour().setAggressive(false);
-                        npc.getCombatDefinition().setAggressive(false);
-                        npc.getBehaviour().setRespawn(false);
-                    } else {
-                        npc.getBehaviour().setRespawn(true);
-                        npc.getBehaviour().setRespawnWhenPlayerOwned(true);
-                    }
-                    area.add(npc);
-                    spawned++;
+        // scale counts based on desired density
+        int areaTiles = (bounds.getMaximumX() - bounds.getMinimumX() + 1) * (bounds.getMaximumY() - bounds.getMinimumY() + 1);
+        int desiredTotal = Math.max(1, areaTiles / Math.max(1, tier.getDesiredNpcDensity()));
+        int baseTotal = Arrays.stream(mobs).mapToInt(BossMob::getCount).sum();
+        double ratio = baseTotal > 0 ? Math.max(1.0, (double) desiredTotal / baseTotal) : 1.0;
+
+        Position spawnTile = tier.getSpawnTile();
+        for (BossMob mob : mobs) {
+            int targetCount = (int) Math.ceil(mob.getCount() * ratio);
+            int spawned = 0;
+            int attempts = 0;
+            int delay = 0;
+            while (spawned < targetCount && attempts++ < targetCount * 5) {
+                int x = Misc.random(bounds.getMinimumX() + 1, bounds.getMaximumX() - 1);
+                int y = Misc.random(bounds.getMinimumY() + 1, bounds.getMaximumY() - 1);
+                if (Misc.distance(spawnTile.getX(), spawnTile.getY(), x, y) > MINIMUM_AGGRO_RANGE) {
+                    continue; // ensure within aggro range
                 }
+                final int fx = x;
+                final int fy = y;
+                final BossMob fmob = mob;
+                final boolean fpreview = preview;
+                CycleEventHandler.getSingleton().addEvent(player, new CycleEvent() {
+                    @Override
+                    public void execute(CycleEventContainer container) {
+                        NpcStats base = NpcStats.forId(fmob.getNpcId());
+                        NpcStatsBuilder builder = NpcStats.builder();
+                        builder.from(base);
+                        builder.setHitpoints((int) (fmob.getHitpoints() * profile.getHpMultiplier()));
+                        builder.setAttackLevel((int) (fmob.getAttack() * profile.getAttackMultiplier()));
+                        builder.setDefenceLevel((int) (fmob.getDefence() * profile.getDefenceMultiplier()));
+                        builder.setAttackSpeed((int) Math.max(1, base.getAttackSpeed() / profile.getAttackSpeedMultiplier()));
+                        NPC npc = NPCSpawning.spawnNpc(player, fmob.getNpcId(), fx, fy,
+                                height, 0, 0, false, false, builder.createNpcStats());
+                        if (npc != null) {
+                            if (fpreview) {
+                                npc.getBehaviour().setAggressive(false);
+                                npc.getCombatDefinition().setAggressive(false);
+                                npc.getBehaviour().setRespawn(false);
+                            } else {
+                                npc.getBehaviour().setAggressive(true);
+                                npc.getCombatDefinition().setAggressive(true);
+                                npc.getBehaviour().setRespawn(true);
+                                npc.getBehaviour().setRespawnWhenPlayerOwned(true);
+                            }
+                            List<NpcSpecialAttack> specials = NpcSpecialAttackLoader.getAll(fmob.getSpecialAttacks());
+                            if (!specials.isEmpty()) {
+                                List<NpcSpecialAttack> scaled = new ArrayList<>();
+                                for (NpcSpecialAttack sa : specials) {
+                                    scaled.add(sa.withAdjustedChance(sa.getActivationChance() * profile.getSpecialFrequencyMultiplier()));
+                                }
+                                npc.getAttributes().set("tier_special_attacks", scaled);
+                            }
+                            area.add(npc);
+                        }
+                        container.stop();
+                    }
+                }, delay);
+                delay += 2;
+                spawned++;
+            }
+            if (spawned < targetCount) {
+                Misc.println("BossInstanceManager warning: spawned " + spawned + "/" + targetCount
+                        + " NPCs for id " + mob.getNpcId());
             }
         }
     }
@@ -277,12 +424,38 @@ public class BossInstanceManager {
         return player.getUnlockedBossTiers().add(tier);
     }
 
+    /** Reloads NPCs and hazards for an existing instance area. */
+    public static void reloadArea(BossInstanceArea area) {
+        if (area == null) return;
+        area.getHazardScheduler().stop();
+        for (NPC n : new ArrayList<>(area.getNpcs())) {
+            n.unregister();
+        }
+        spawnInstanceGrid(area.owner, area.getTier(), area, false);
+        area.startHazards();
+        InstanceMutatorManager.resetDanger();
+    }
+
     /** Removes the player from their boss instance and clears overlay text. */
     public static void leave(Player player) {
         BossInstanceOverlayManager.clear(player);
         BossInstanceArea area = INSTANCES.remove(player);
         if (area != null) {
             area.dispose();
+        }
+        InstancePerformanceTracker.InstanceResult result = player.getInstancePerformanceTracker().finish();
+        if (result != null) {
+            long seconds = java.util.concurrent.TimeUnit.MILLISECONDS.toSeconds(result.timeMs);
+            player.sendMessage("@blu@Instance complete in " + seconds + "s, score: " + result.score);
+            // Update personal bests
+            player.getBestInstanceScores().merge(result.tier, result.score, Math::max);
+            player.getBestInstanceTimes().merge(result.tier, result.timeMs, Math::min);
+            InstanceRewardLoader.giveRewards(player, result.score);
+            InstanceLeaderboard.record(player.getLoginName(), result.tier, result.timeMs, result.score);
+            PerformanceRank rank = PerformanceRank.forScore(result.score);
+            if (rank.ordinal() >= PerformanceRank.GOLD.ordinal()) {
+                player.sendMessage("@gre@Achievement unlocked: " + rank.name() + " performer!");
+            }
         }
         player.setPreviewingBossInstance(false);
     }
@@ -341,5 +514,14 @@ public class BossInstanceManager {
     /** Returns the active instance for a player or {@code null} if none. */
     public static BossInstanceArea get(Player player) {
         return INSTANCES.get(player);
+    }
+
+    /** Returns an arbitrary active area for the given tier, or {@code null} if none exist. */
+    public static BossInstanceArea getAny(BossTier tier) {
+        return INSTANCES.values().stream().filter(a -> a.getTier() == tier).findFirst().orElse(null);
+    }
+
+    public static int getMinimumAggroRange() {
+        return MINIMUM_AGGRO_RANGE;
     }
 }

--- a/src/io/xeros/content/instances/BossInstanceOverlayManager.java
+++ b/src/io/xeros/content/instances/BossInstanceOverlayManager.java
@@ -2,6 +2,8 @@ package io.xeros.content.instances;
 
 import io.xeros.model.entity.player.Player;
 
+import static io.xeros.content.instances.InstanceMutatorManager.getActiveDisplay;
+
 /**
  * Handles displaying boss instance progress information to players.
  */
@@ -21,11 +23,11 @@ public class BossInstanceOverlayManager {
         int current = player.getTierKillCounts().getOrDefault(tier, 0);
         BossInstanceManager.BossTier next = tier.getNextTier();
 
-//        player.getPA().sendFrame126("\uD83E\uDDF1 Tier: " + BossInstanceManager.getTierDisplayNameSafe(tier), 8144);
-//        player.getPA().sendFrame126("\u2620\uFE0F Kills: " + current + " / " + tier.getRequiredKillCountToUnlockNext(), 8145);
-//        player.getPA().sendFrame126("\uD83D\uDD13 Unlocks: " + (next != null ? BossInstanceManager.getTierDisplayNameSafe(next) : "Maxed"), 8146);
-//        player.getPA().sendFrame126("", 8147);
-        player.getPA().sendFrame126("", 8148);
+        player.getPA().sendFrame126("\uD83E\uDDF1 Tier: " + BossInstanceManager.getTierDisplayNameSafe(tier), 8144);
+        player.getPA().sendFrame126("\u2620\uFE0F Kills: " + current + " / " + tier.getRequiredKillCountToUnlockNext(), 8145);
+        player.getPA().sendFrame126("\uD83D\uDD13 Unlocks: " + (next != null ? BossInstanceManager.getTierDisplayNameSafe(next) : "Maxed"), 8146);
+        player.getPA().sendFrame126("Mutators: " + getActiveDisplay(), 8147);
+        player.getPA().sendFrame126("Danger: " + InstanceMutatorManager.getDangerLevel() + "%", 8148);
     }
 
     /**

--- a/src/io/xeros/content/instances/InstanceLeaderboard.java
+++ b/src/io/xeros/content/instances/InstanceLeaderboard.java
@@ -1,0 +1,43 @@
+package io.xeros.content.instances;
+
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import java.util.*;
+
+/**
+ * Simple in-memory leaderboard for fastest times and highest scores per tier.
+ * This does not persist across server restarts.
+ */
+public class InstanceLeaderboard {
+
+    public static class Entry implements Comparable<Entry> {
+        public final String player;
+        public final long time;
+        public final int score;
+        public Entry(String player, long time, int score) {
+            this.player = player;
+            this.time = time;
+            this.score = score;
+        }
+        @Override
+        public int compareTo(Entry o) {
+            int diff = Integer.compare(o.score, score);
+            if (diff == 0) diff = Long.compare(time, o.time);
+            if (diff == 0) diff = player.compareTo(o.player);
+            return diff;
+        }
+    }
+
+    private static final Map<BossTier, NavigableSet<Entry>> LEADERBOARDS = new EnumMap<>(BossTier.class);
+
+    public static void record(String player, BossTier tier, long time, int score) {
+        NavigableSet<Entry> set = LEADERBOARDS.computeIfAbsent(tier, t -> new TreeSet<>());
+        set.add(new Entry(player, time, score));
+        while (set.size() > 10) {
+            set.pollLast();
+        }
+    }
+
+    public static List<Entry> top(BossTier tier) {
+        return new ArrayList<>(LEADERBOARDS.getOrDefault(tier, Collections.emptyNavigableSet()));
+    }
+}

--- a/src/io/xeros/content/instances/InstanceMutator.java
+++ b/src/io/xeros/content/instances/InstanceMutator.java
@@ -1,0 +1,10 @@
+package io.xeros.content.instances;
+
+public enum InstanceMutator {
+    DOUBLE_HAZARD_MODE,
+    NO_PRAYER_RECOVERY,
+    RANDOM_BOSS_PHASE_SHIFT,
+    UNSTABLE_TILES,
+    VENOMOUS,
+    ANOMALY
+}

--- a/src/io/xeros/content/instances/InstanceMutatorManager.java
+++ b/src/io/xeros/content/instances/InstanceMutatorManager.java
@@ -1,0 +1,182 @@
+package io.xeros.content.instances;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.xeros.util.Misc;
+
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.*;
+import io.xeros.content.instances.hazard.EnvironmentalHazardType;
+import io.xeros.content.instances.hazard.HazardEffectModifier;
+import io.xeros.model.cycleevent.CycleEvent;
+import io.xeros.model.cycleevent.CycleEventContainer;
+import io.xeros.model.cycleevent.CycleEventHandler;
+import io.xeros.model.entity.player.PlayerHandler;
+import java.util.stream.Collectors;
+
+/**
+ * Manages weekly mutator rotations, active mutators and the global danger
+ * meter for AOE instances.
+ */
+public class InstanceMutatorManager {
+
+    private static class MutatorConfig {
+        MutatorRarity rarity;
+        public MutatorRarity getRarity() { return rarity; }
+    }
+
+    private static final Map<InstanceMutator, MutatorConfig> DEFINITIONS = new EnumMap<>(InstanceMutator.class);
+    private static final List<MutatorSynergy> SYNERGIES = new ArrayList<>();
+    private static final EnumSet<InstanceMutator> ACTIVE = EnumSet.noneOf(InstanceMutator.class);
+    private static int dangerLevel;
+    private static int globalDanger;
+    private static final Map<InstanceMutator, List<HazardEffectModifier>> HAZARD_SYNERGIES = new EnumMap<>(InstanceMutator.class);
+    private static final List<String> SYNERGY_LOG = new ArrayList<>();
+    /** Owner used for global cycle events. */
+    private static final Object EVENT_OWNER = new Object();
+
+    static {
+        try {
+            Type type = new TypeToken<Map<String, MutatorConfig>>(){}.getType();
+            InputStreamReader reader = new InputStreamReader(InstanceMutatorManager.class.getResourceAsStream("/aoe_mutators.json"));
+            Map<String, MutatorConfig> defs = new Gson().fromJson(reader, type);
+            for (Map.Entry<String, MutatorConfig> e : defs.entrySet()) {
+                InstanceMutator mutator = InstanceMutator.valueOf(e.getKey().toUpperCase());
+                DEFINITIONS.put(mutator, e.getValue());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            Type type = new TypeToken<List<MutatorSynergy>>(){}.getType();
+            InputStreamReader reader = new InputStreamReader(InstanceMutatorManager.class.getResourceAsStream("/aoe_mutator_synergies.json"));
+            List<MutatorSynergy> synergies = new Gson().fromJson(reader, type);
+            if (synergies != null) {
+                SYNERGIES.addAll(synergies);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        // hazard synergy definitions
+        HAZARD_SYNERGIES.put(InstanceMutator.VENOMOUS,
+                List.of(new HazardEffectModifier(EnvironmentalHazardType.POISON_MIST, 1.5,
+                        "Venomous mutator intensifies the toxic fumes!")));
+        // decay global danger every ~60s
+        CycleEventHandler.getSingleton().addEvent(EVENT_OWNER, new CycleEvent() {
+            @Override
+            public void execute(CycleEventContainer container) {
+                globalDanger = Math.max(0, globalDanger - 1);
+                if (globalDanger > 80) {
+                    PlayerHandler.executeGlobalMessage("@red@The world trembles from hazardous energy!");
+                }
+            }
+        }, 100);
+    }
+
+    /** Rolls a new weekly set of mutators based on rarity weights. */
+    public static void rollWeeklyMutators() {
+        ACTIVE.clear();
+        List<InstanceMutator> pool = new ArrayList<>(DEFINITIONS.keySet());
+        while (ACTIVE.size() < 2 && !pool.isEmpty()) {
+            InstanceMutator pick = weightedRandom(pool);
+            ACTIVE.add(pick);
+            pool.remove(pick);
+        }
+        // roll anomaly slot
+        if (Misc.random(99) == 0 && DEFINITIONS.containsKey(InstanceMutator.ANOMALY)) {
+            ACTIVE.add(InstanceMutator.ANOMALY);
+        }
+        checkSynergies();
+    }
+
+    private static InstanceMutator weightedRandom(List<InstanceMutator> pool) {
+        int total = pool.stream().mapToInt(p -> DEFINITIONS.get(p).getRarity().getWeight()).sum();
+        int roll = Misc.random(total - 1);
+        int cumulative = 0;
+        for (InstanceMutator m : pool) {
+            cumulative += DEFINITIONS.get(m).getRarity().getWeight();
+            if (roll < cumulative) {
+                return m;
+            }
+        }
+        return pool.get(0);
+    }
+
+    private static void checkSynergies() {
+        for (MutatorSynergy synergy : SYNERGIES) {
+            if (ACTIVE.containsAll(synergy.getMutators())) {
+                // For now simply raise danger as a placeholder effect
+                increaseDanger(20);
+            }
+        }
+    }
+
+    public static boolean isActive(InstanceMutator mutator) {
+        return ACTIVE.contains(mutator);
+    }
+
+    public static void toggle(InstanceMutator mutator) {
+        if (ACTIVE.contains(mutator)) {
+            ACTIVE.remove(mutator);
+        } else {
+            ACTIVE.add(mutator);
+        }
+        checkSynergies();
+    }
+
+    public static String getActiveDisplay() {
+        if (ACTIVE.isEmpty()) {
+            return "None";
+        }
+        return ACTIVE.stream().map(Enum::name).collect(Collectors.joining(", "));
+    }
+
+    public static void increaseDanger(int amount) {
+        dangerLevel = Math.min(100, dangerLevel + amount);
+        spikeGlobal(amount / 2);
+        if (dangerLevel >= 100) {
+            // placeholder: would spawn mega hazard or boss
+        }
+    }
+
+    public static int getDangerLevel() {
+        return dangerLevel;
+    }
+
+    public static void resetDanger() {
+        dangerLevel = 0;
+    }
+
+    public static void spikeGlobal(int amount) {
+        globalDanger = Math.min(100, globalDanger + amount);
+    }
+
+    public static int getGlobalDanger() {
+        return globalDanger;
+    }
+
+    public static Set<InstanceMutator> getActiveMutators() {
+        return EnumSet.copyOf(ACTIVE);
+    }
+
+    public static MutatorRarity getRarity(InstanceMutator mutator) {
+        MutatorConfig cfg = DEFINITIONS.get(mutator);
+        return cfg == null ? MutatorRarity.COMMON : cfg.getRarity();
+    }
+
+    public static List<HazardEffectModifier> getHazardSynergies(InstanceMutator mutator) {
+        return HAZARD_SYNERGIES.getOrDefault(mutator, List.of());
+    }
+
+    public static void logSynergy(String message) {
+        SYNERGY_LOG.add(message);
+        if (SYNERGY_LOG.size() > 50) {
+            SYNERGY_LOG.remove(0);
+        }
+    }
+
+    public static List<String> getSynergyLog() {
+        return SYNERGY_LOG;
+    }
+}

--- a/src/io/xeros/content/instances/InstancePerformanceTracker.java
+++ b/src/io/xeros/content/instances/InstancePerformanceTracker.java
@@ -1,0 +1,80 @@
+package io.xeros.content.instances;
+
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tracks per-instance performance statistics such as time, damage dealt/taken
+ * and special-attack dodges. Used for scoring and reward crates when the
+ * player leaves the instance.
+ */
+public class InstancePerformanceTracker {
+
+    private long startTime;
+    private long damageDealt;
+    private long damageTaken;
+    private int specialDodges;
+    private BossTier tier;
+
+    /** Starts tracking for a new instance. */
+    public void start(BossTier tier) {
+        this.tier = tier;
+        this.startTime = System.currentTimeMillis();
+        this.damageDealt = 0;
+        this.damageTaken = 0;
+        this.specialDodges = 0;
+    }
+
+    /** Records final results and resets the tracker. */
+    public InstanceResult finish() {
+        if (startTime == 0 || tier == null) {
+            return null;
+        }
+        long time = System.currentTimeMillis() - startTime;
+        int score = calculateScore(tier, time, damageDealt, damageTaken, specialDodges);
+        InstanceResult result = new InstanceResult(tier, time, score);
+        startTime = 0;
+        tier = null;
+        damageDealt = 0;
+        damageTaken = 0;
+        specialDodges = 0;
+        return result;
+    }
+
+    public void addDamageDealt(int amount) {
+        damageDealt += Math.max(0, amount);
+    }
+
+    public void addDamageTaken(int amount) {
+        damageTaken += Math.max(0, amount);
+    }
+
+    public void addSpecialDodge() {
+        specialDodges++;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public static int calculateScore(BossTier tier, long timeMs, long dealt, long taken, int dodges) {
+        double timeScore = Math.max(1, TimeUnit.MILLISECONDS.toSeconds(timeMs));
+        double efficiency = dealt > 0 ? (double)(dealt - taken) / dealt : 0;
+        double tierMult = tier.ordinal() + 1;
+        double base = tierMult * 1000;
+        double score = base + (efficiency * 500) + (dodges * 50) - (timeScore * 10);
+        return (int)Math.max(0, Math.round(score));
+    }
+
+    /** Container for a finished run. */
+    public static class InstanceResult {
+        public final BossTier tier;
+        public final long timeMs;
+        public final int score;
+        public InstanceResult(BossTier tier, long timeMs, int score) {
+            this.tier = tier;
+            this.timeMs = timeMs;
+            this.score = score;
+        }
+    }
+}

--- a/src/io/xeros/content/instances/InstanceRewardLoader.java
+++ b/src/io/xeros/content/instances/InstanceRewardLoader.java
@@ -1,0 +1,50 @@
+package io.xeros.content.instances;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads reward crate definitions for instance performance scores.
+ */
+public class InstanceRewardLoader {
+
+    private static final Map<PerformanceRank, List<GameItem>> REWARDS = new EnumMap<>(PerformanceRank.class);
+
+    static {
+        try {
+            Type type = new TypeToken<Map<String, List<GameItem>>>(){}.getType();
+            InputStreamReader reader = new InputStreamReader(InstanceRewardLoader.class.getResourceAsStream("/instance_rewards.json"));
+            Map<String, List<GameItem>> map = new Gson().fromJson(reader, type);
+            for (Map.Entry<String, List<GameItem>> e : map.entrySet()) {
+                PerformanceRank rank = PerformanceRank.valueOf(e.getKey().toUpperCase());
+                REWARDS.put(rank, e.getValue());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /** Rolls a reward crate based on the player's final score. */
+    public static void giveRewards(io.xeros.model.entity.player.Player player, int score) {
+        PerformanceRank rank = PerformanceRank.forScore(score);
+        List<GameItem> items = REWARDS.get(rank);
+        if (items != null) {
+            for (GameItem item : items) {
+                player.getItems().addItem(item.getId(), item.getAmount());
+            }
+        }
+        // Ultra rare roll scales with score.
+        double chance = Math.max(1, 500 - (score / 100));
+        if (Misc.random((int)chance) == 0) {
+            player.getItems().addItem(4151, 1); // example ultra loot
+            player.sendMessage("@dre@You have received an ultra rare item!");
+        }
+    }
+}

--- a/src/io/xeros/content/instances/MutatorRarity.java
+++ b/src/io/xeros/content/instances/MutatorRarity.java
@@ -1,0 +1,21 @@
+package io.xeros.content.instances;
+
+/**
+ * Rarity tiers for instance mutators used for weekly rotations.
+ */
+public enum MutatorRarity {
+    COMMON(50),
+    UNCOMMON(30),
+    RARE(15),
+    LEGENDARY(5);
+
+    private final int weight;
+
+    MutatorRarity(int weight) {
+        this.weight = weight;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+}

--- a/src/io/xeros/content/instances/MutatorSynergy.java
+++ b/src/io/xeros/content/instances/MutatorSynergy.java
@@ -1,0 +1,15 @@
+package io.xeros.content.instances;
+
+import java.util.List;
+
+/**
+ * Defines a multi-mutator synergy event. When all mutators in the list are
+ * active a named combo effect can be triggered.
+ */
+public class MutatorSynergy {
+    private List<InstanceMutator> mutators;
+    private String name;
+
+    public List<InstanceMutator> getMutators() { return mutators; }
+    public String getName() { return name; }
+}

--- a/src/io/xeros/content/instances/NpcSpecialAttack.java
+++ b/src/io/xeros/content/instances/NpcSpecialAttack.java
@@ -1,0 +1,38 @@
+package io.xeros.content.instances;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Definition for a special attack an instance NPC can use.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NpcSpecialAttack {
+    private String name;
+    /** chance between 0 and 1 */
+    private double activationChance;
+    /** cooldown in game ticks */
+    private int cooldown;
+    private int animation;
+    private int gfx;
+    private int sound;
+    /** free form effect identifier for combat script */
+    private String effect;
+    /** optional combat dialogue lines */
+    private List<String> messages;
+
+    public NpcSpecialAttack copy() {
+        return new NpcSpecialAttack(name, activationChance, cooldown, animation, gfx, sound, effect, messages);
+    }
+
+    public NpcSpecialAttack withAdjustedChance(double chance) {
+        NpcSpecialAttack copy = copy();
+        copy.setActivationChance(chance);
+        return copy;
+    }
+}

--- a/src/io/xeros/content/instances/NpcSpecialAttackLoader.java
+++ b/src/io/xeros/content/instances/NpcSpecialAttackLoader.java
@@ -1,0 +1,48 @@
+package io.xeros.content.instances;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads special attack definitions from json and allows lookup by name.
+ */
+public class NpcSpecialAttackLoader {
+    private static final Map<String, NpcSpecialAttack> SPECIALS = new HashMap<>();
+    private static final Path FILE = Path.of("resources/boss_instance_special_attacks.json");
+
+    static {
+        if (Files.exists(FILE)) {
+            try {
+                List<NpcSpecialAttack> list = new Gson().fromJson(Files.newBufferedReader(FILE),
+                        new TypeToken<List<NpcSpecialAttack>>() {}.getType());
+                for (NpcSpecialAttack sa : list) {
+                    SPECIALS.put(sa.getName(), sa);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static List<NpcSpecialAttack> getAll(List<String> names) {
+        List<NpcSpecialAttack> list = new ArrayList<>();
+        if (names == null) {
+            return list;
+        }
+        for (String name : names) {
+            NpcSpecialAttack sa = SPECIALS.get(name);
+            if (sa != null) {
+                list.add(sa.copy());
+            }
+        }
+        return list;
+    }
+}

--- a/src/io/xeros/content/instances/PerformanceRank.java
+++ b/src/io/xeros/content/instances/PerformanceRank.java
@@ -1,0 +1,32 @@
+package io.xeros.content.instances;
+
+/**
+ * Ranks based on instance score which drive reward crates and achievements.
+ */
+public enum PerformanceRank {
+    BRONZE(0),
+    SILVER(1000),
+    GOLD(2000),
+    PLATINUM(3000),
+    DIAMOND(4000);
+
+    private final int threshold;
+
+    PerformanceRank(int threshold) {
+        this.threshold = threshold;
+    }
+
+    public int getThreshold() {
+        return threshold;
+    }
+
+    public static PerformanceRank forScore(int score) {
+        PerformanceRank result = BRONZE;
+        for (PerformanceRank r : values()) {
+            if (score >= r.threshold) {
+                result = r;
+            }
+        }
+        return result;
+    }
+}

--- a/src/io/xeros/content/instances/TierCombatProfile.java
+++ b/src/io/xeros/content/instances/TierCombatProfile.java
@@ -1,0 +1,32 @@
+package io.xeros.content.instances;
+
+import java.util.List;
+
+/**
+ * Tier wide combat settings and multipliers applied to mobs when spawned.
+ */
+public class TierCombatProfile {
+    private final double hpMultiplier;
+    private final double attackMultiplier;
+    private final double defenceMultiplier;
+    private final double attackSpeedMultiplier;
+    private final double specialFrequencyMultiplier;
+    private final List<String> allowedSpecials;
+
+    public TierCombatProfile(double hpMultiplier, double attackMultiplier, double defenceMultiplier,
+                             double attackSpeedMultiplier, double specialFrequencyMultiplier, List<String> allowedSpecials) {
+        this.hpMultiplier = hpMultiplier;
+        this.attackMultiplier = attackMultiplier;
+        this.defenceMultiplier = defenceMultiplier;
+        this.attackSpeedMultiplier = attackSpeedMultiplier;
+        this.specialFrequencyMultiplier = specialFrequencyMultiplier;
+        this.allowedSpecials = allowedSpecials;
+    }
+
+    public double getHpMultiplier() { return hpMultiplier; }
+    public double getAttackMultiplier() { return attackMultiplier; }
+    public double getDefenceMultiplier() { return defenceMultiplier; }
+    public double getAttackSpeedMultiplier() { return attackSpeedMultiplier; }
+    public double getSpecialFrequencyMultiplier() { return specialFrequencyMultiplier; }
+    public List<String> getAllowedSpecials() { return allowedSpecials; }
+}

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardDefinition.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardDefinition.java
@@ -1,0 +1,183 @@
+package io.xeros.content.instances.hazard;
+
+import io.xeros.content.combat.Hitmark;
+import io.xeros.content.instances.BossInstanceManager;
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.hazard.HazardTier;
+import io.xeros.content.instances.hazard.IHazardReactive;
+import io.xeros.content.instances.hazard.HazardContext;
+import io.xeros.content.instances.hazard.HazardReaction;
+import io.xeros.content.instances.hazard.HazardDebugLogger;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.cycleevent.CycleEvent;
+import io.xeros.model.cycleevent.CycleEventContainer;
+import io.xeros.model.cycleevent.CycleEventHandler;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+import io.xeros.util.Misc;
+
+public class EnvironmentalHazardDefinition {
+
+    private EnvironmentalHazardType type;
+    private int damage;
+    private int drain;
+    private int stun;
+    private int duration;
+    private String triggerCondition;
+    private int cooldownWindow;
+    private HazardTier tier = HazardTier.BASIC;
+
+    public EnvironmentalHazardType getType() { return type; }
+    public int getDamage() { return damage; }
+    public int getDrain() { return drain; }
+    public int getStun() { return stun; }
+    public int getDuration() { return duration; }
+    public String getTriggerCondition() { return triggerCondition; }
+    public int getCooldownWindow() { return cooldownWindow; }
+    public HazardTier getTier() { return tier; }
+
+    public HazardContext activate(BossInstanceArea area, HazardTier finalTier, double dmgMod, String synergyMsg) {
+        return activate(area, finalTier, dmgMod, synergyMsg, null);
+    }
+
+    public HazardContext activate(BossInstanceArea area, HazardTier finalTier, double dmgMod, String synergyMsg, Position forced) {
+        Boundary b = area.getTier().getZoneBoundary();
+        int x = forced != null ? forced.getX() : Misc.random(b.getMinimumX(), b.getMaximumX());
+        int y = forced != null ? forced.getY() : Misc.random(b.getMinimumY(), b.getMaximumY());
+        Position pos = new Position(x, y, area.getHeight());
+        int scaledDamage = (int) (finalTier.scale(damage) * dmgMod);
+        int scaledDrain = (int) (finalTier.scale(drain) * dmgMod);
+        int scaledStun = (int) (finalTier.scale(stun) * dmgMod);
+        HazardContext ctx = new HazardContext(type, finalTier, pos);
+        HazardDebugLogger.log(area, "Hazard " + type + " at " + pos);
+        if (synergyMsg != null) {
+            for (Player p : area.getPlayers()) {
+                p.sendMessage(synergyMsg);
+            }
+        }
+        switch (type) {
+            case FIRE_TILE:
+                CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+                    int ticks;
+                    @Override
+                    public void execute(CycleEventContainer container) {
+                        java.util.List<String> names = new java.util.ArrayList<>();
+                        for (Player p : area.getPlayers()) {
+                            if (p.getPosition().equals(pos)) {
+                                p.appendDamage(scaledDamage, Hitmark.HIT);
+                                names.add(p.getDisplayName());
+                                HazardReaction r = ((IHazardReactive)p).onHazardTriggered(ctx);
+                                // players currently have no reactions
+                            }
+                        }
+                        for (NPC n : area.getNpcs()) {
+                            if (n.getPosition().equals(pos) && n instanceof IHazardReactive) {
+                                HazardReaction r = ((IHazardReactive)n).onHazardTriggered(ctx);
+                                HazardDebugLogger.logNpcReaction(area, n, ctx);
+                                if (r != null) {
+                                    CycleEventHandler.getSingleton().addEvent(n, new CycleEvent() {
+                                        @Override
+                                        public void execute(CycleEventContainer container) {
+                                            r.getAction().accept(n);
+                                            container.stop();
+                                        }
+                                    }, r.getDelay());
+                                }
+                                names.add(n.getName());
+                            }
+                        }
+                        if (!names.isEmpty()) {
+                            area.getHazardScheduler().recordDamage(type + " -> " + String.join(",", names));
+                        }
+                        if (++ticks >= duration) {
+                            container.stop();
+                        }
+                    }
+                }, 1);
+                break;
+            case POISON_MIST:
+                CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+                    int ticks;
+                    @Override
+                    public void execute(CycleEventContainer container) {
+                        java.util.List<String> names = new java.util.ArrayList<>();
+                        for (Player p : area.getPlayers()) {
+                            Position pp = p.getPosition();
+                            if (Math.abs(pp.getX() - x) <= 1 && Math.abs(pp.getY() - y) <= 1 && pp.getHeight() == pos.getHeight()) {
+                                p.prayerPoint = Math.max(0, p.prayerPoint - scaledDrain);
+                                p.getPA().refreshSkill(5);
+                                p.sendMessage("@pur@Poison mist drains your prayer!");
+                                HazardReaction r = ((IHazardReactive)p).onHazardTriggered(ctx);
+                                names.add(p.getDisplayName());
+                            }
+                        }
+                        for (NPC n : area.getNpcs()) {
+                            Position np = n.getPosition();
+                            if (Math.abs(np.getX() - x) <= 1 && Math.abs(np.getY() - y) <= 1 && np.getHeight() == pos.getHeight()) {
+                                HazardReaction r = ((IHazardReactive)n).onHazardTriggered(ctx);
+                                HazardDebugLogger.logNpcReaction(area, n, ctx);
+                                if (r != null) {
+                                    CycleEventHandler.getSingleton().addEvent(n, new CycleEvent() {
+                                        @Override
+                                        public void execute(CycleEventContainer container) {
+                                            r.getAction().accept(n);
+                                            container.stop();
+                                        }
+                                    }, r.getDelay());
+                                }
+                                names.add(n.getName());
+                            }
+                        }
+                        if (!names.isEmpty()) {
+                            area.getHazardScheduler().recordDamage(type + " -> " + String.join(",", names));
+                        }
+                        if (++ticks >= duration) {
+                            container.stop();
+                        }
+                    }
+                }, 1);
+                break;
+            case CRUMBLING_FLOOR:
+                CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+                    int ticks;
+                    @Override
+                    public void execute(CycleEventContainer container) {
+                        java.util.List<String> names = new java.util.ArrayList<>();
+                        for (Player p : area.getPlayers()) {
+                            if (p.getPosition().equals(pos)) {
+                                p.freezeTimer = Math.max(p.freezeTimer, scaledStun);
+                                p.sendMessage("@red@The floor collapses beneath you!");
+                                HazardReaction r = ((IHazardReactive)p).onHazardTriggered(ctx);
+                                names.add(p.getDisplayName());
+                            }
+                        }
+                        for (NPC n : area.getNpcs()) {
+                            if (n.getPosition().equals(pos) && n instanceof IHazardReactive) {
+                                HazardReaction r = ((IHazardReactive)n).onHazardTriggered(ctx);
+                                HazardDebugLogger.logNpcReaction(area, n, ctx);
+                                if (r != null) {
+                                    CycleEventHandler.getSingleton().addEvent(n, new CycleEvent() {
+                                        @Override
+                                        public void execute(CycleEventContainer container) {
+                                            r.getAction().accept(n);
+                                            container.stop();
+                                        }
+                                    }, r.getDelay());
+                                }
+                                names.add(n.getName());
+                            }
+                        }
+                        if (!names.isEmpty()) {
+                            area.getHazardScheduler().recordDamage(type + " -> " + String.join(",", names));
+                        }
+                        if (++ticks >= duration) {
+                            container.stop();
+                        }
+                    }
+                }, 1);
+                break;
+        }
+        return ctx;
+    }
+}

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardLoader.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardLoader.java
@@ -1,0 +1,40 @@
+package io.xeros.content.instances.hazard;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.xeros.content.instances.BossInstanceManager;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public class EnvironmentalHazardLoader {
+
+    public static class HazardConfig {
+        private int frequency;
+        private List<EnvironmentalHazardDefinition> hazards;
+        public int getFrequency() { return frequency; }
+        public List<EnvironmentalHazardDefinition> getHazards() { return hazards; }
+    }
+
+    private static final Map<BossInstanceManager.BossTier, HazardConfig> CONFIGS = new EnumMap<>(BossInstanceManager.BossTier.class);
+
+    static {
+        try {
+            Type type = new TypeToken<Map<String, HazardConfig>>(){}.getType();
+            InputStreamReader reader = new InputStreamReader(EnvironmentalHazardLoader.class.getResourceAsStream("/aoe_environmental_hazards.json"));
+            Map<String, HazardConfig> map = new Gson().fromJson(reader, type);
+            for (Map.Entry<String, HazardConfig> e : map.entrySet()) {
+                BossInstanceManager.BossTier tier = BossInstanceManager.BossTier.valueOf(e.getKey().toUpperCase());
+                CONFIGS.put(tier, e.getValue());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static HazardConfig get(BossInstanceManager.BossTier tier) {
+        return CONFIGS.get(tier);
+    }
+}

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
@@ -1,0 +1,82 @@
+package io.xeros.content.instances.hazard;
+
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.model.cycleevent.CycleEvent;
+import io.xeros.model.cycleevent.CycleEventContainer;
+import io.xeros.model.cycleevent.CycleEventHandler;
+import io.xeros.model.entity.player.Player;
+
+/**
+ * Simple arena wide hazard patterns. The behaviour here is intentionally
+ * lightweight and extensible so more elaborate effects can be added later.
+ */
+public class EnvironmentalHazardPattern {
+
+    public enum PatternType {
+        FLAME_RING,
+        VOID_PULSE,
+        TOXIC_TORRENT,
+        SHOCKWAVE,
+        CHAOS_RIFT
+    }
+
+    private PatternType type;
+
+    public PatternType getType() {
+        return type;
+    }
+
+    public void setType(PatternType type) {
+        this.type = type;
+    }
+
+    /**
+     * Activate the pattern for the supplied area.
+     */
+    public void activate(BossInstanceArea area) {
+        switch (type) {
+            case VOID_PULSE:
+                // simple: stun all players briefly
+                for (Player p : area.getPlayers()) {
+                    p.freezeTimer = Math.max(p.freezeTimer, 5);
+                    p.sendMessage("@blu@A void pulse shocks you!");
+                }
+                break;
+            case TOXIC_TORRENT:
+                for (Player p : area.getPlayers()) {
+                    p.prayerPoint = Math.max(0, p.prayerPoint - 10);
+                    p.getPA().refreshSkill(5);
+                    p.sendMessage("@gre@Toxic fumes drain your prayer!");
+                }
+                break;
+            case SHOCKWAVE:
+                for (Player p : area.getPlayers()) {
+                    p.appendDamage(10, io.xeros.content.combat.Hitmark.HIT);
+                }
+                break;
+            case CHAOS_RIFT:
+                for (Player p : area.getPlayers()) {
+                    p.getPA().movePlayer(p.getPosition().getX() + io.xeros.util.Misc.random(-1,1),
+                            p.getPosition().getY() + io.xeros.util.Misc.random(-1,1), p.getHeight());
+                    p.sendMessage("@pur@Chaotic forces warp your position!");
+                }
+                break;
+            case FLAME_RING:
+            default:
+                // damage all players mildly
+                CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+                    int ticks;
+                    @Override
+                    public void execute(CycleEventContainer container) {
+                        for (Player p : area.getPlayers()) {
+                            p.appendDamage(5, io.xeros.content.combat.Hitmark.HIT);
+                        }
+                        if (++ticks >= 5) {
+                            container.stop();
+                        }
+                    }
+                }, 1);
+                break;
+        }
+    }
+}

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardPatternLoader.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardPatternLoader.java
@@ -1,0 +1,45 @@
+package io.xeros.content.instances.hazard;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.xeros.content.instances.BossInstanceManager.BossTier;
+
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads arena wide hazard patterns per tier from json.
+ */
+public class EnvironmentalHazardPatternLoader {
+
+    public static class PatternConfig {
+        private int frequency;
+        private List<EnvironmentalHazardPattern> patterns;
+
+        public int getFrequency() { return frequency; }
+        public List<EnvironmentalHazardPattern> getPatterns() { return patterns; }
+    }
+
+    private static final Map<BossTier, PatternConfig> CONFIGS = new EnumMap<>(BossTier.class);
+
+    static {
+        try {
+            Type type = new TypeToken<Map<String, PatternConfig>>(){}.getType();
+            InputStreamReader reader = new InputStreamReader(EnvironmentalHazardPatternLoader.class.getResourceAsStream("/aoe_environmental_patterns.json"));
+            Map<String, PatternConfig> map = new Gson().fromJson(reader, type);
+            for (Map.Entry<String, PatternConfig> e : map.entrySet()) {
+                BossTier tier = BossTier.valueOf(e.getKey().toUpperCase());
+                CONFIGS.put(tier, e.getValue());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static PatternConfig get(BossTier tier) {
+        return CONFIGS.get(tier);
+    }
+}

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
@@ -1,0 +1,198 @@
+package io.xeros.content.instances.hazard;
+
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.content.instances.InstanceMutator;
+import io.xeros.content.instances.InstanceMutatorManager;
+import io.xeros.content.instances.hazard.HazardTier;
+import io.xeros.content.instances.hazard.HazardEffectModifier;
+import io.xeros.content.instances.hazard.WeeklyHazardManager;
+import io.xeros.content.instances.hazard.HazardDebugLogger;
+import io.xeros.model.cycleevent.CycleEvent;
+import io.xeros.model.cycleevent.CycleEventContainer;
+import io.xeros.model.cycleevent.CycleEventHandler;
+import io.xeros.model.entity.player.Player;
+import io.xeros.util.Misc;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class EnvironmentalHazardScheduler {
+
+    private final BossInstanceArea area;
+    private boolean started;
+    private final Map<String, Long> cooldowns = new HashMap<>();
+    private boolean inProgress;
+    private final Map<EnvironmentalHazardType, HazardRecord> lastHazards = new EnumMap<>(EnvironmentalHazardType.class);
+    private String lastDamageTick = "none";
+
+    public EnvironmentalHazardScheduler(BossInstanceArea area) {
+        this.area = area;
+    }
+
+    public void start() {
+        if (started) {
+            return;
+        }
+        EnvironmentalHazardLoader.HazardConfig config = EnvironmentalHazardLoader.get(area.getTier());
+        EnvironmentalHazardPatternLoader.PatternConfig patternConfig = EnvironmentalHazardPatternLoader.get(area.getTier());
+        WeeklyHazardManager.WeeklyHazardConfig weekly = WeeklyHazardManager.get();
+        if (config != null && config.getHazards() != null && !config.getHazards().isEmpty()) {
+            started = true;
+            int frequency = config.getFrequency();
+            if (InstanceMutatorManager.isActive(InstanceMutator.DOUBLE_HAZARD_MODE)) {
+                frequency = Math.max(1, frequency / 2);
+            }
+            final List<EnvironmentalHazardDefinition> pool = config.getHazards().stream()
+                    .filter(h -> weekly == null || weekly.staticHazards.contains(h.getType()))
+                    .collect(Collectors.toList());
+            int finalFrequency = frequency;
+            CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+                @Override
+                public void execute(CycleEventContainer container) {
+                    if (inProgress || pool.isEmpty()) {
+                        return;
+                    }
+                    inProgress = true;
+                    EnvironmentalHazardDefinition def = Misc.randomTypeOfList(pool);
+                    HazardTier hazardTier = determineTier(def.getTier());
+                    double dmgMod = 1.0;
+                    String synergyMsg = null;
+                    for (InstanceMutator mut : InstanceMutatorManager.getActiveMutators()) {
+                        if (weekly != null && !weekly.synergyMutators.contains(mut)) {
+                            continue;
+                        }
+                        for (HazardEffectModifier mod : InstanceMutatorManager.getHazardSynergies(mut)) {
+                            if (mod.getTarget() == def.getType()) {
+                                dmgMod *= mod.getDamageMultiplier();
+                                synergyMsg = mod.getMessage();
+                                InstanceMutatorManager.logSynergy(mut.name() + " -> " + def.getType());
+                            }
+                        }
+                    }
+                    HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                    recordLast(def, ctx);
+                    InstanceMutatorManager.increaseDanger(5);
+                    inProgress = false;
+                }
+            }, finalFrequency);
+            if (weekly != null && weekly.eliteHazard != null) {
+                CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+                    @Override
+                    public void execute(CycleEventContainer container) {
+                        if (InstanceMutatorManager.getGlobalDanger() >= 80) {
+                            EnvironmentalHazardDefinition elite = pool.stream()
+                                    .filter(h -> h.getType() == weekly.eliteHazard)
+                                    .findFirst().orElse(null);
+                            if (elite != null) {
+                                elite.activate(area, HazardTier.EXTREME, 1.0, "@red@Elite hazard empowered by global danger!");
+                                InstanceMutatorManager.increaseDanger(10);
+                            }
+                        }
+                    }
+                }, 100);
+            }
+        }
+        if (patternConfig != null && patternConfig.getPatterns() != null && !patternConfig.getPatterns().isEmpty()) {
+            int pfreq = patternConfig.getFrequency();
+            CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+                @Override
+                public void execute(CycleEventContainer container) {
+                    EnvironmentalHazardPattern pattern = Misc.randomTypeOfList(patternConfig.getPatterns());
+                    pattern.activate(area);
+                    InstanceMutatorManager.increaseDanger(10);
+                }
+            }, pfreq);
+        }
+    }
+
+    public void stop() {
+        CycleEventHandler.getSingleton().stopEvents(area);
+    }
+
+    /**
+     * Called by external systems when a reactive trigger occurs.
+     */
+    public void trigger(String trigger, Player player) {
+        EnvironmentalHazardLoader.HazardConfig config = EnvironmentalHazardLoader.get(area.getTier());
+        if (config == null || config.getHazards() == null) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        for (EnvironmentalHazardDefinition def : config.getHazards()) {
+            if (trigger.equalsIgnoreCase(def.getTriggerCondition())) {
+                long last = cooldowns.getOrDefault(trigger, 0L);
+                if (now - last < def.getCooldownWindow()) {
+                    continue;
+                }
+                HazardTier hazardTier = determineTier(def.getTier());
+                double dmgMod = 1.0;
+                String synergyMsg = null;
+                for (InstanceMutator mut : InstanceMutatorManager.getActiveMutators()) {
+                    if (weekly != null && !weekly.synergyMutators.contains(mut)) {
+                        continue;
+                    }
+                    for (HazardEffectModifier mod : InstanceMutatorManager.getHazardSynergies(mut)) {
+                        if (mod.getTarget() == def.getType()) {
+                            dmgMod *= mod.getDamageMultiplier();
+                            synergyMsg = mod.getMessage();
+                            InstanceMutatorManager.logSynergy(mut.name() + " -> " + def.getType());
+                        }
+                    }
+                }
+                HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                recordLast(def, ctx);
+                cooldowns.put(trigger, now);
+                InstanceMutatorManager.increaseDanger(7);
+            }
+        }
+    }
+
+    private HazardTier determineTier(HazardTier base) {
+        HazardTier result = base;
+        int danger = InstanceMutatorManager.getDangerLevel();
+        int roll = Misc.random(99);
+        if (danger > 66 && roll < danger - 66) {
+            result = HazardTier.EXTREME;
+        } else if (danger > 33 && roll < danger - 33) {
+            result = HazardTier.ADVANCED;
+        }
+        return result;
+    }
+
+    /** Returns human readable debugging information for admin commands. */
+    public List<String> debugState() {
+        List<String> list = new ArrayList<>();
+        list.add("started=" + started + ", inProgress=" + inProgress);
+        list.add("cooldowns=" + cooldowns.toString());
+        list.add("lastHazards=" + lastHazards.keySet());
+        list.add("lastDamage=" + lastDamageTick);
+        list.addAll(InstanceMutatorManager.getSynergyLog());
+        return list;
+        }
+
+    private void recordLast(EnvironmentalHazardDefinition def, HazardContext ctx) {
+        lastHazards.put(def.getType(), new HazardRecord(def, ctx));
+        HazardDebugLogger.log(area, "trigger:" + def.getType());
+    }
+
+    public void recordDamage(String info) {
+        lastDamageTick = info;
+        HazardDebugLogger.log(area, "damage:" + info);
+    }
+
+    public boolean replay(EnvironmentalHazardType type) {
+        HazardRecord r = lastHazards.get(type);
+        if (r == null) return false;
+        r.def.activate(area, r.ctx.getTier(), 1.0, null, r.ctx.getPosition());
+        HazardDebugLogger.log(area, "replay:" + type);
+        return true;
+    }
+
+    private static class HazardRecord {
+        final EnvironmentalHazardDefinition def;
+        final HazardContext ctx;
+        HazardRecord(EnvironmentalHazardDefinition def, HazardContext ctx) {
+            this.def = def; this.ctx = ctx;
+        }
+    }
+}

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardType.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardType.java
@@ -1,0 +1,7 @@
+package io.xeros.content.instances.hazard;
+
+public enum EnvironmentalHazardType {
+    FIRE_TILE,
+    POISON_MIST,
+    CRUMBLING_FLOOR
+}

--- a/src/io/xeros/content/instances/hazard/HazardContext.java
+++ b/src/io/xeros/content/instances/hazard/HazardContext.java
@@ -1,0 +1,41 @@
+package io.xeros.content.instances.hazard;
+
+import io.xeros.model.entity.player.Position;
+
+/**
+ * Context describing a hazard activation instance passed to reactive
+ * listeners such as NPCs or players.
+ */
+public class HazardContext {
+    private final EnvironmentalHazardType type;
+    private final HazardTier tier;
+    private final Position position;
+    private final java.util.List<Position> affectedTiles;
+
+    public HazardContext(EnvironmentalHazardType type, HazardTier tier, Position position) {
+        this(type, tier, position, java.util.List.of(position));
+    }
+
+    public HazardContext(EnvironmentalHazardType type, HazardTier tier, Position position, java.util.List<Position> affectedTiles) {
+        this.type = type;
+        this.tier = tier;
+        this.position = position;
+        this.affectedTiles = affectedTiles;
+    }
+
+    public EnvironmentalHazardType getType() {
+        return type;
+    }
+
+    public HazardTier getTier() {
+        return tier;
+    }
+
+    public Position getPosition() {
+        return position;
+    }
+
+    public java.util.List<Position> getAffectedTiles() {
+        return affectedTiles;
+    }
+}

--- a/src/io/xeros/content/instances/hazard/HazardDebugLogger.java
+++ b/src/io/xeros/content/instances/hazard/HazardDebugLogger.java
@@ -1,0 +1,53 @@
+package io.xeros.content.instances.hazard;
+
+import io.xeros.content.instances.BossInstanceManager.BossInstanceArea;
+import io.xeros.model.entity.npc.NPC;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+/** Utility class to track hazard reaction debug information per instance. */
+public class HazardDebugLogger {
+    private static final Map<BossInstanceArea, Deque<String>> NPC_LOGS = new HashMap<>();
+    private static final Map<BossInstanceArea, List<String>> AUDIT_LOGS = new HashMap<>();
+
+    public static void logNpcReaction(BossInstanceArea area, NPC npc, HazardContext ctx) {
+        Deque<String> q = NPC_LOGS.computeIfAbsent(area, k -> new ArrayDeque<>());
+        String time = new SimpleDateFormat("HH:mm:ss").format(new Date());
+        String line = "[" + time + "] " + npc.getName() + " -> " + ctx.getType();
+        q.add(line);
+        log(area, line);
+        if (q.size() > 25) {
+            q.removeFirst();
+        }
+    }
+
+    public static void log(BossInstanceArea area, String message) {
+        String time = new SimpleDateFormat("HH:mm:ss").format(new Date());
+        List<String> logs = AUDIT_LOGS.computeIfAbsent(area, k -> new ArrayList<>());
+        logs.add("[" + time + "] " + message);
+        if (logs.size() > 200) {
+            logs.remove(0);
+        }
+    }
+
+    public static List<String> getNpcLogs(BossInstanceArea area) {
+        Deque<String> q = NPC_LOGS.get(area);
+        if (q == null) {
+            return List.of();
+        }
+        return new ArrayList<>(q);
+    }
+
+    public static List<String> getAuditLogs(BossInstanceArea area) {
+        return AUDIT_LOGS.getOrDefault(area, List.of());
+    }
+
+    public static void dump(BossInstanceArea area, java.nio.file.Path path) throws java.io.IOException {
+        java.nio.file.Files.write(path, getAuditLogs(area));
+    }
+
+    public static void clear(BossInstanceArea area) {
+        NPC_LOGS.remove(area);
+        AUDIT_LOGS.remove(area);
+    }
+}

--- a/src/io/xeros/content/instances/hazard/HazardEffectModifier.java
+++ b/src/io/xeros/content/instances/hazard/HazardEffectModifier.java
@@ -1,0 +1,28 @@
+package io.xeros.content.instances.hazard;
+
+/**
+ * Describes how a mutator modifies a particular hazard effect.
+ */
+public class HazardEffectModifier {
+    private final EnvironmentalHazardType target;
+    private final double damageMultiplier;
+    private final String message;
+
+    public HazardEffectModifier(EnvironmentalHazardType target, double damageMultiplier, String message) {
+        this.target = target;
+        this.damageMultiplier = damageMultiplier;
+        this.message = message;
+    }
+
+    public EnvironmentalHazardType getTarget() {
+        return target;
+    }
+
+    public double getDamageMultiplier() {
+        return damageMultiplier;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/io/xeros/content/instances/hazard/HazardReaction.java
+++ b/src/io/xeros/content/instances/hazard/HazardReaction.java
@@ -1,0 +1,45 @@
+package io.xeros.content.instances.hazard;
+
+import io.xeros.model.entity.npc.NPC;
+
+import java.util.function.Consumer;
+
+/**
+ * Describes a delayed reaction an {@link IHazardReactive} entity can perform
+ * after a hazard triggers. Reactions have a priority to allow weighting and a
+ * delay in ticks before the action executes.
+ */
+public class HazardReaction {
+
+    private final String name;
+    private final int priority;
+    private final int delay;
+    private final Consumer<NPC> action;
+
+    public HazardReaction(String name, int priority, int delay, Consumer<NPC> action) {
+        this.name = name;
+        this.priority = priority;
+        this.delay = delay;
+        this.action = action;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public int getDelay() {
+        return delay;
+    }
+
+    public Consumer<NPC> getAction() {
+        return action;
+    }
+
+    public static HazardReaction of(String name, int priority, int delay, Consumer<NPC> action) {
+        return new HazardReaction(name, priority, delay, action);
+    }
+}

--- a/src/io/xeros/content/instances/hazard/HazardTier.java
+++ b/src/io/xeros/content/instances/hazard/HazardTier.java
@@ -1,0 +1,20 @@
+package io.xeros.content.instances.hazard;
+
+/**
+ * Severity tier for arena environmental hazards. Higher tiers
+ * scale damage and other effects to make hazards more punishing.
+ */
+public enum HazardTier {
+    BASIC(1.0),
+    ADVANCED(1.5),
+    EXTREME(2.0);
+
+    private final double scale;
+    HazardTier(double scale) {
+        this.scale = scale;
+    }
+
+    public int scale(int base) {
+        return (int) Math.max(1, Math.round(base * scale));
+    }
+}

--- a/src/io/xeros/content/instances/hazard/IHazardReactive.java
+++ b/src/io/xeros/content/instances/hazard/IHazardReactive.java
@@ -1,0 +1,13 @@
+package io.xeros.content.instances.hazard;
+
+/**
+ * Objects that can react to environmental hazard triggers implement this
+ * interface. Default method allows classes to opt-in without boilerplate.
+ */
+public interface IHazardReactive {
+
+    default HazardReaction onHazardTriggered(HazardContext ctx) {
+        // Default no-op.
+        return null;
+    }
+}

--- a/src/io/xeros/content/instances/hazard/WeeklyHazardManager.java
+++ b/src/io/xeros/content/instances/hazard/WeeklyHazardManager.java
@@ -1,0 +1,49 @@
+package io.xeros.content.instances.hazard;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.xeros.content.instances.InstanceMutator;
+
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Loads and stores the weekly rotating hazard set and mutator synergies.
+ */
+public class WeeklyHazardManager {
+
+    public static class WeeklyHazardConfig {
+        public List<EnvironmentalHazardType> staticHazards = new ArrayList<>();
+        public List<InstanceMutator> synergyMutators = new ArrayList<>();
+        public EnvironmentalHazardType eliteHazard;
+    }
+
+    private static WeeklyHazardConfig config = new WeeklyHazardConfig();
+
+    public static WeeklyHazardConfig get() {
+        return config;
+    }
+
+    public static void load() {
+        try {
+            Type type = new TypeToken<WeeklyHazardConfig>(){}.getType();
+            InputStreamReader reader = new InputStreamReader(WeeklyHazardManager.class.getResourceAsStream("/aoe_weekly_hazards.json"));
+            WeeklyHazardConfig loaded = new Gson().fromJson(reader, type);
+            if (loaded != null) {
+                config = loaded;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void reload() {
+        load();
+    }
+
+    static {
+        load();
+    }
+}

--- a/src/io/xeros/content/items/aoeweapons/AoeManager.java
+++ b/src/io/xeros/content/items/aoeweapons/AoeManager.java
@@ -10,9 +10,8 @@ import io.xeros.model.collisionmap.doors.Location;
 import io.xeros.model.entity.Entity;
 import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.npc.NPCHandler;
-import io.xeros.model.entity.player.Boundary;
+import io.xeros.content.instances.BossInstanceManager;
 import io.xeros.model.entity.player.Player;
-import io.xeros.model.entity.player.Position;
 import io.xeros.util.Misc;
 
 import java.util.Arrays;
@@ -24,7 +23,8 @@ public class AoeManager {
 
     public static boolean canAOE(Player player) {
 
-        return Boundary.isIn(player, Boundary.AOEInstance) &&
+        BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(player);
+        return area != null && area.isWithinAoeZone(player.getPosition()) &&
                 Arrays.stream(AoeWeapons.values()).anyMatch(i -> i.ID == player.playerEquipment[Player.playerWeapon]);
     }
 
@@ -50,12 +50,16 @@ public class AoeManager {
         player.startAnimation(anim);
 
         if (player.isPlayer() && victim.isNPC()) {
+            BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(player);
             victim.startGraphic(new Graphic(gfx, 0, Graphic.GraphicHeight.MIDDLE));
             for (NPC next : NPCHandler.npcs) {
                 if (next == null) {
                     continue;
                 }
                 if (next.getInstance() != player.getInstance() || next.getHeight() != player.getHeight()) {
+                    continue;
+                }
+                if (area != null && !area.isWithinAoeZone(next.getPosition())) {
                     continue;
                 }
                 if (!player.getPosition().withinDistance(next.getPosition(), range) || next.getHealth().getCurrentHealth() <= 0) {

--- a/src/io/xeros/model/entity/npc/NPC.java
+++ b/src/io/xeros/model/entity/npc/NPC.java
@@ -37,6 +37,9 @@ import io.xeros.model.entity.npc.stats.NpcCombatDefinition;
 import io.xeros.model.entity.npc.stats.NpcCombatSkill;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
+import io.xeros.content.instances.hazard.IHazardReactive;
+import io.xeros.content.instances.hazard.HazardContext;
+import io.xeros.content.instances.hazard.HazardReaction;
 import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.model.entity.player.Position;
 import io.xeros.model.entity.thrall.ThrallSystem;
@@ -52,7 +55,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class NPC extends Entity {
+public class NPC extends Entity implements IHazardReactive {
 
     public List<Player> localPlayers = new ArrayList<>();
 
@@ -1409,6 +1412,9 @@ public class NPC extends Entity {
             }
 
             addDamageTaken(player, damage);
+            if (player.getInstance() instanceof io.xeros.content.instances.BossInstanceManager.BossInstanceArea) {
+                player.getInstancePerformanceTracker().addDamageDealt(damage);
+            }
 
             if (player.getRaidsInstance() != null && Boundary.isIn(player, Boundary.FULL_RAIDS)) {
                 Raids.damage(player, damage);
@@ -1547,5 +1553,18 @@ public class NPC extends Entity {
         };
 
     }
-
+    @Override
+    public HazardReaction onHazardTriggered(HazardContext ctx) {
+        int delay = Misc.random(2, 6);
+        switch (ctx.getType()) {
+            case FIRE_TILE:
+                return HazardReaction.of("Vengeance Shout", 1, delay, n -> n.forceChat("Vengeance!"));
+            case CRUMBLING_FLOOR:
+                return HazardReaction.of("Phase Shift", 2, delay, n -> n.forceChat("Phase shift!"));
+            case POISON_MIST:
+                return HazardReaction.of("Toxic Drain", 1, delay, n -> n.forceChat("Toxic drain!"));
+            default:
+                return null;
+        }
+    }
 }

--- a/src/io/xeros/model/entity/npc/actions/NpcAggression.java
+++ b/src/io/xeros/model/entity/npc/actions/NpcAggression.java
@@ -9,6 +9,7 @@ import io.xeros.content.bosses.wildypursuit.FragmentOfSeren;
 import io.xeros.content.bosses.zulrah.Zulrah;
 import io.xeros.content.minigames.arbograve.ArbograveConstants;
 import io.xeros.content.questing.hftd.DagannothMother;
+import io.xeros.content.instances.BossInstanceManager;
 import io.xeros.model.Bonus;
 import io.xeros.model.Npcs;
 import io.xeros.model.entity.npc.NPC;
@@ -177,6 +178,9 @@ public class NpcAggression {
     }
 
     private static int getAggressionDistance(NPC npc, Player player, int baseDistance) {
+        if (Boundary.isIn(npc, Boundary.AOEInstance)) {
+            return Math.max(baseDistance, BossInstanceManager.getMinimumAggroRange());
+        }
         if (Boundary.isIn(npc, Boundary.GODWARS_BOSSROOMS) && npc.getNpcId() > 0) return 25;
         if (Boundary.isIn(npc, Boundary.GODWARS_OTHER_ROOMS) && npc.getNpcId() > 0) return 8;
         if (Boundary.isIn(npc, Boundary.SARACHNIS_LAIR) || Boundary.isIn(npc, Boundary.MIMIC_LAIR) || Boundary.isIn(npc, Boundary.GROTESQUE_LAIR))

--- a/src/io/xeros/model/entity/player/Boundary.java
+++ b/src/io/xeros/model/entity/player/Boundary.java
@@ -542,7 +542,7 @@ public class Boundary {
 
 
 	public static final Boundary Wilderness_Slayer = new Boundary(3328, 10048, 3455, 10175);
-	public static final	Boundary AOEInstance = new Boundary(2880, 5440, 2943, 5503);
+	public static final	Boundary AOEInstance = new Boundary(2273, 4762, 2292, 4781);
 	public static final Boundary WILDERNESS = new Boundary(2941, 3525, 3392, 3968);
 	public static final Boundary WILDERNESS_UNDERGROUND = new Boundary(2980, 10048, 3473, 10373);
 	public static final Boundary[] WILDERNESS_PARAMETERS = {WILDERNESS, WILDERNESS_UNDERGROUND, WILDERNESS_GOD_WARS_BOUNDARY, REV_CAVE};

--- a/src/io/xeros/model/entity/player/Player.java
+++ b/src/io/xeros/model/entity/player/Player.java
@@ -31,6 +31,7 @@ import io.xeros.content.bosspoints.BossPoints;
 import io.xeros.content.cheatprevention.RandomEventInterface;
 import io.xeros.content.collection_log.CollectionLog;
 import io.xeros.content.combat.CombatItems;
+import io.xeros.content.instances.BossInstanceManager;
 import io.xeros.content.combat.EntityDamageQueue;
 import io.xeros.content.combat.Hitmark;
 import io.xeros.content.combat.core.AttackEntity;
@@ -77,6 +78,9 @@ import io.xeros.content.items.pouch.RunePouch;
 import io.xeros.content.itemskeptondeath.perdu.PerduLostPropertyShop;
 import io.xeros.content.leaderboards.LeaderboardPeriodicity;
 import io.xeros.content.leaderboards.LeaderboardUtils;
+import io.xeros.content.instances.hazard.IHazardReactive;
+import io.xeros.content.instances.hazard.HazardContext;
+import io.xeros.content.instances.hazard.HazardReaction;
 import io.xeros.content.lootbag.LootingBag;
 import io.xeros.content.minigames.arbograve.ArbograveConstants;
 import io.xeros.content.minigames.arbograve.ArbograveContainer;
@@ -228,7 +232,7 @@ import java.util.stream.IntStream;
 import static io.xeros.util.discord.DiscordIntegration.updateDiscordInterface;
 import static io.xeros.util.discord.DiscordIntegration.updateDiscordPoints;
 
-public class Player extends Entity {
+public class Player extends Entity implements IHazardReactive {
 
     private static Logger logger = LoggerFactory.getLogger(Player.class);
 
@@ -838,6 +842,12 @@ public class Player extends Entity {
     private java.util.EnumSet<io.xeros.content.instances.BossInstanceManager.BossTier> unlockedBossTiers = java.util.EnumSet.of(io.xeros.content.instances.BossInstanceManager.BossTier.TIER1);
     /** Kill counts tracked per {@link io.xeros.content.instances.BossInstanceManager.BossTier}. */
     private final java.util.EnumMap<io.xeros.content.instances.BossInstanceManager.BossTier, Integer> tierKillCounts = new java.util.EnumMap<>(io.xeros.content.instances.BossInstanceManager.BossTier.class);
+    /** Best performance score achieved per tier. */
+    private final java.util.EnumMap<io.xeros.content.instances.BossInstanceManager.BossTier, Integer> bestInstanceScores = new java.util.EnumMap<>(io.xeros.content.instances.BossInstanceManager.BossTier.class);
+    /** Fastest completion time per tier in milliseconds. */
+    private final java.util.EnumMap<io.xeros.content.instances.BossInstanceManager.BossTier, Long> bestInstanceTimes = new java.util.EnumMap<>(io.xeros.content.instances.BossInstanceManager.BossTier.class);
+    /** Runtime tracker for the active boss instance. */
+    private final io.xeros.content.instances.InstancePerformanceTracker instancePerformanceTracker = new io.xeros.content.instances.InstancePerformanceTracker();
     public int totalEarnedExchangePoints;
     public int referallFlag;
     public int amDonated;
@@ -2399,7 +2409,10 @@ public class Player extends Entity {
         if (heal > getHealth().getMaximumHealth()) getHealth().reset();
         getHealth().increase(amount);
         getPA().refreshSkill(3);
-
+        BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(this);
+        if (area != null && amount >= getHealth().getMaximumHealth() * 0.3) {
+            area.getHazardScheduler().trigger("HEAL_BIG", this);
+        }
     }
 
     public void resetOnDeath() {
@@ -4526,6 +4539,10 @@ public class Player extends Entity {
 
         MeleeExtras.handleRedemption(this, damage);
 
+        if (getInstance() instanceof io.xeros.content.instances.BossInstanceManager.BossInstanceArea) {
+            instancePerformanceTracker.addDamageTaken(damage);
+        }
+
         if (entity != null && entity.isPlayer()) playerHitIndex = entity.asPlayer().getIndex();
 
         if (teleTimer <= 0) {
@@ -6253,6 +6270,18 @@ public class Player extends Entity {
         return tierKillCounts;
     }
 
+    public java.util.EnumMap<io.xeros.content.instances.BossInstanceManager.BossTier, Integer> getBestInstanceScores() {
+        return bestInstanceScores;
+    }
+
+    public java.util.EnumMap<io.xeros.content.instances.BossInstanceManager.BossTier, Long> getBestInstanceTimes() {
+        return bestInstanceTimes;
+    }
+
+    public io.xeros.content.instances.InstancePerformanceTracker getInstancePerformanceTracker() {
+        return instancePerformanceTracker;
+    }
+
     public BlastFurnace getBlastFurnace() {
         return blastFurnace;
     }
@@ -6452,5 +6481,11 @@ public class Player extends Entity {
 
     public void setPreviewingBossInstance(boolean previewingBossInstance) {
         this.previewingBossInstance = previewingBossInstance;
+    }
+
+    @Override
+    public HazardReaction onHazardTriggered(HazardContext ctx) {
+        // Players currently have no special reactions.
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- track and replay recent hazards per zone with `::replayhazard` and expose live hazard status and logs via new admin commands
- give NPCs weighted hazard reactions and support optional mutator and hazard vision overlays for visual debugging
- enable dynamic wave scaling in boss arenas so instances can spawn extra waves based on time and global danger level
- fix mutator manager startup and confine all tiers to the new arena boundary

## Testing
- `gradle --console=plain test` *(fails: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*

------
https://chatgpt.com/codex/tasks/task_e_68928bbe0fd083208e1b5e22f58def78