### PR TITLE
Fix AoE instance boundary logic and hazard bounds

### DIFF
--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -10,6 +10,7 @@ import io.xeros.model.entity.npc.NPCSpawning;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.Position;
+import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.util.Misc;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
@@ -83,7 +84,10 @@ public class BossInstanceManager {
         }
 
         public boolean isWithinAoeZone(Position pos) {
-            return true;
+            Boundary boundary = tier.getZoneBoundary();
+            return pos.getHeight() == getHeight()
+                    && pos.getX() >= boundary.getMinimumX() && pos.getX() <= boundary.getMaximumX()
+                    && pos.getY() >= boundary.getMinimumY() && pos.getY() <= boundary.getMaximumY();
         }
 
         public io.xeros.content.instances.hazard.EnvironmentalHazardScheduler getHazardScheduler() {
@@ -356,6 +360,11 @@ public class BossInstanceManager {
         int desiredTotal = Math.max(1, areaTiles / Math.max(1, tier.getDesiredNpcDensity()));
         int baseTotal = Arrays.stream(mobs).mapToInt(BossMob::getCount).sum();
         double ratio = baseTotal > 0 ? Math.max(1.0, (double) desiredTotal / baseTotal) : 1.0;
+        if (tier.ordinal() <= BossTier.TIER4.ordinal()) {
+            ratio *= 1.2;
+        } else if (tier.ordinal() >= BossTier.TIER7.ordinal()) {
+            ratio *= 0.8;
+        }
 
         Position spawnTile = tier.getSpawnTile();
         for (BossMob mob : mobs) {
@@ -455,6 +464,11 @@ public class BossInstanceManager {
             PerformanceRank rank = PerformanceRank.forScore(result.score);
             if (rank.ordinal() >= PerformanceRank.GOLD.ordinal()) {
                 player.sendMessage("@gre@Achievement unlocked: " + rank.name() + " performer!");
+            }
+            int kills = player.getTierKillCounts().getOrDefault(result.tier, 0);
+            if (kills >= result.tier.getRequiredKillCountToUnlockNext()) {
+                String msg = player.getDisplayName() + " has completed " + getTierDisplayNameSafe(result.tier) + "!";
+                PlayerHandler.nonNullStream().forEach(p -> p.sendMessage(msg));
             }
         }
         player.setPreviewingBossInstance(false);

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
@@ -5,6 +5,7 @@ import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Boundary;
 
 /**
  * Simple arena wide hazard patterns. The behaviour here is intentionally
@@ -55,9 +56,13 @@ public class EnvironmentalHazardPattern {
                 }
                 break;
             case CHAOS_RIFT:
+                Boundary b = area.getTier().getZoneBoundary();
                 for (Player p : area.getPlayers()) {
-                    p.getPA().movePlayer(p.getPosition().getX() + io.xeros.util.Misc.random(-1,1),
-                            p.getPosition().getY() + io.xeros.util.Misc.random(-1,1), p.getHeight());
+                    int nx = p.getPosition().getX() + io.xeros.util.Misc.random(-1,1);
+                    int ny = p.getPosition().getY() + io.xeros.util.Misc.random(-1,1);
+                    nx = Math.max(b.getMinimumX(), Math.min(b.getMaximumX(), nx));
+                    ny = Math.max(b.getMinimumY(), Math.min(b.getMaximumY(), ny));
+                    p.getPA().movePlayer(nx, ny, area.getHeight());
                     p.sendMessage("@pur@Chaotic forces warp your position!");
                 }
                 break;

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
@@ -11,6 +11,8 @@ import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Position;
 import io.xeros.util.Misc;
 
 import java.util.*;
@@ -71,7 +73,8 @@ public class EnvironmentalHazardScheduler {
                             }
                         }
                     }
-                    HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                    Position rand = randomPosition();
+                    HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg, rand);
                     recordLast(def, ctx);
                     InstanceMutatorManager.increaseDanger(5);
                     inProgress = false;
@@ -86,7 +89,8 @@ public class EnvironmentalHazardScheduler {
                                     .filter(h -> h.getType() == weekly.eliteHazard)
                                     .findFirst().orElse(null);
                             if (elite != null) {
-                                elite.activate(area, HazardTier.EXTREME, 1.0, "@red@Elite hazard empowered by global danger!");
+                                Position rand = randomPosition();
+                                elite.activate(area, HazardTier.EXTREME, 1.0, "@red@Elite hazard empowered by global danger!", rand);
                                 InstanceMutatorManager.increaseDanger(10);
                             }
                         }
@@ -141,7 +145,8 @@ public class EnvironmentalHazardScheduler {
                         }
                     }
                 }
-                HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                Position rand = randomPosition();
+                HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg, rand);
                 recordLast(def, ctx);
                 cooldowns.put(trigger, now);
                 InstanceMutatorManager.increaseDanger(7);
@@ -185,7 +190,8 @@ public class EnvironmentalHazardScheduler {
     public boolean replay(EnvironmentalHazardType type) {
         HazardRecord r = lastHazards.get(type);
         if (r == null) return false;
-        r.def.activate(area, r.ctx.getTier(), 1.0, null, r.ctx.getPosition());
+        Position pos = clampPosition(r.ctx.getPosition());
+        r.def.activate(area, r.ctx.getTier(), 1.0, null, pos);
         HazardDebugLogger.log(area, "replay:" + type);
         return true;
     }
@@ -196,5 +202,19 @@ public class EnvironmentalHazardScheduler {
         HazardRecord(EnvironmentalHazardDefinition def, HazardContext ctx) {
             this.def = def; this.ctx = ctx;
         }
+    }
+
+    private Position randomPosition() {
+        Boundary b = area.getTier().getZoneBoundary();
+        int x = Misc.random(b.getMinimumX(), b.getMaximumX());
+        int y = Misc.random(b.getMinimumY(), b.getMaximumY());
+        return clampPosition(new Position(x, y, area.getHeight()));
+    }
+
+    private Position clampPosition(Position pos) {
+        Boundary b = area.getTier().getZoneBoundary();
+        int x = Math.max(b.getMinimumX(), Math.min(b.getMaximumX(), pos.getX()));
+        int y = Math.max(b.getMinimumY(), Math.min(b.getMaximumY(), pos.getY()));
+        return new Position(x, y, area.getHeight());
     }
 }


### PR DESCRIPTION
## Summary
- Properly restrict AoE checks to instance zone boundaries
- Adjust NPC spawn scaling by tier in AoE zones
- Clamp hazard and pattern positions inside instance bounds and broadcast instance completions

## Testing
- `gradle test` *(fails: Execution failed for task ':compileJava'.)*

------
https://chatgpt.com/codex/tasks/task_e_6896b12cc3d88320be53ac720ea302e8