### PR TITLE
Refactor Demon Hunter Slayer dialogue and rewards

### DIFF
--- a/src/io/xeros/content/skills/slayer/DemonHunterSlayerDialogue.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterSlayerDialogue.java
@@ -19,75 +19,48 @@ import java.util.stream.Collectors;
 /**
  * Dialogue interface for the Demon Hunter Slayer Master NPC.
  */
-public class DemonHunterSlayerDialogue extends DialogueBuilder {
+public class DemonHunterSlayerDialogue {
 
     private static final int NPC = Npcs.DEMON_HUNTER_MASTER;
 
-    public DemonHunterSlayerDialogue(Player player) {
-        super(player);
-        setNpcId(NPC);
-        npc("Greetings, slayer. How can I assist you on your Demon Hunter journey?");
-        List<DialogueOption> options = new ArrayList<>();
-        options.add(new DialogueOption("What's Demon Hunter Slayer?", this::explainSystem));
-        options.add(new DialogueOption("What are the Demon Hunter Slayer tiers?", this::explainTiers));
-        options.add(new DialogueOption("What are the rewards and XP like?", this::explainRewards));
-        options.add(new DialogueOption("View Current Task", this::viewTask));
-        options.add(new DialogueOption("Abandon Task", this::abandonTask));
-        options.add(new DialogueOption("View Stats / Contract", this::viewStats));
-        options.add(new DialogueOption("Open Reward Shop", this::openShop));
-        if (player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
-            options.add(new DialogueOption("Admin Options", this::adminMenu));
-        }
-        option(options.toArray(new DialogueOption[0]));
-    }
-
-    private void explainSystem(Player player) {
+    /**
+     * Opens the main Demon Hunter menu.
+     */
+    public static void showMainMenu(Player player) {
         DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
-        builder.npc("Demon Hunter Slayer is an elite slayer mode focused on defeating demon bosses.");
-        builder.npc("You'll receive powerful assignments based on your Demon Hunter level.");
-        builder.npc("Progress builds your streak, earns Slayer XP, and rewards Demon Marks.");
-        builder.npc("Milestones unlock perks and elite tasks, and contracts offer extra rewards.");
-        builder.npc("Track your progress, climb the leaderboard, and claim your glory.");
-        builder.option(new DialogueOption("Got it. Back to menu.", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        builder.npc("Greetings, slayer. How can I assist you on your Demon Hunter journey?");
+
+        List<DialogueOption> options = new ArrayList<>();
+        options.add(new DialogueOption("What's Demon Hunter Slayer?", DemonHunterSlayerDialogue::explainSystem));
+        options.add(new DialogueOption("What are the Demon Hunter tiers?", DemonHunterSlayerDialogue::explainTiers));
+        options.add(new DialogueOption("What are the rewards and XP like?", DemonHunterSlayerDialogue::explainRewards));
+        options.add(new DialogueOption("Task Menu", DemonHunterSlayerDialogue::showTaskMenu));
+        if (player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
+            options.add(new DialogueOption("Admin Options", DemonHunterSlayerDialogue::showAdminMenu));
+        }
+        builder.option(options.toArray(new DialogueOption[0]));
         player.start(builder);
     }
 
-    private void viewTask(Player player) {
-        if (player.getDemonHunterTask().isEmpty()) {
-            player.sendMessage("You don't currently have a Demon Hunter task.");
-            return;
-        }
-        DemonHunterTaskOverlayManager.schedule(player);
-        player.sendMessage("Your task overlay has been refreshed.");
+    /**
+     * Opens the task management submenu.
+     */
+    public static void showTaskMenu(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.option(
+                new DialogueOption("View Current Task", DemonHunterSlayerDialogue::viewTask),
+                new DialogueOption("Abandon Task", DemonHunterSlayerDialogue::abandonTask),
+                new DialogueOption("View Stats / Contract", DemonHunterSlayerDialogue::viewStats),
+                new DialogueOption("Open Reward Shop", DemonHunterSlayerDialogue::openShop),
+                new DialogueOption("Back", DemonHunterSlayerDialogue::showMainMenu)
+        );
+        player.start(builder);
     }
 
-    private void abandonTask(Player player) {
-        if (player.getDemonHunterTask().isEmpty()) {
-            player.sendMessage("You don't have a task to abandon.");
-            return;
-        }
-        player.sendMessage("You have abandoned your current task.");
-        player.setDemonHunterTask(null);
-        player.setDemonHunterTaskProgress(0);
-    }
-
-    private void viewStats(Player player) {
-        int level = player.playerLevel[Skill.DEMON_HUNTER.getId()];
-        int streak = player.getDemonTaskStreak();
-        int marks = player.getDemonMarks();
-        player.sendMessage("Demon Hunter Level: " + level);
-        player.sendMessage("Task Streak: " + streak);
-        player.sendMessage("Demon Marks: " + marks);
-        player.getDemonContract().ifPresentOrElse(
-                c -> player.sendMessage("Active Contract: Defeat " + c.getAmount() + " " + c.getTarget().getNpcName()),
-                () -> player.sendMessage("Active Contract: none"));
-    }
-
-    private void openShop(Player player) {
-        DemonMarkRewardHandler.openShop(player);
-    }
-
-    private void adminMenu(Player player) {
+    /**
+     * Opens the administrator submenu (page 1).
+     */
+    public static void showAdminMenu(Player player) {
         if (!player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
             player.sendMessage("Only admins can access this.");
             return;
@@ -109,6 +82,17 @@ public class DemonHunterSlayerDialogue extends DialogueBuilder {
                     p.setDemonContract(null);
                     p.sendMessage("Contract cleared.");
                 }),
+                new DialogueOption("More Options", DemonHunterSlayerDialogue::showAdminMenuMore)
+        );
+        player.start(builder);
+    }
+
+    /**
+     * Additional administrator options (page 2).
+     */
+    private static void showAdminMenuMore(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.option(
                 new DialogueOption("View boss XP logs", p -> {
                     for (DemonSlayerMaster.BossTier bt : DemonSlayerMaster.BossTier.values()) {
                         int xp = DemonHunterXPTable.getXPFor(bt.getBaseXp(), bt.getTier());
@@ -116,11 +100,59 @@ public class DemonHunterSlayerDialogue extends DialogueBuilder {
                     }
                 }),
                 new DialogueOption("Open Reward Shop", DemonMarkRewardHandler::openShop),
-                new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+                new DialogueOption("Back", DemonHunterSlayerDialogue::showMainMenu),
+                new DialogueOption("Previous", DemonHunterSlayerDialogue::showAdminMenu)
+        );
         player.start(builder);
     }
 
-    private void explainTiers(Player player) {
+    private static void explainSystem(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.npc("Demon Hunter Slayer is an elite slayer mode focused on defeating demon bosses.");
+        builder.npc("You'll receive powerful assignments based on your Demon Hunter level.");
+        builder.npc("Progress builds your streak, earns Slayer XP, and rewards Demon Marks.");
+        builder.npc("Milestones unlock perks and elite tasks, and contracts offer extra rewards.");
+        builder.npc("Track your progress, climb the leaderboard, and claim your glory.");
+        builder.option(new DialogueOption("Got it. Back to menu.", DemonHunterSlayerDialogue::showMainMenu));
+        player.start(builder);
+    }
+
+    private static void viewTask(Player player) {
+        if (player.getDemonHunterTask().isEmpty()) {
+            player.sendMessage("You don't currently have a Demon Hunter task.");
+            return;
+        }
+        DemonHunterTaskOverlayManager.schedule(player);
+        player.sendMessage("Your task overlay has been refreshed.");
+    }
+
+    private static void abandonTask(Player player) {
+        if (player.getDemonHunterTask().isEmpty()) {
+            player.sendMessage("You don't have a task to abandon.");
+            return;
+        }
+        player.sendMessage("You have abandoned your current task.");
+        player.setDemonHunterTask(null);
+        player.setDemonHunterTaskProgress(0);
+    }
+
+    private static void viewStats(Player player) {
+        int level = player.playerLevel[Skill.DEMON_HUNTER.getId()];
+        int streak = player.getDemonTaskStreak();
+        int marks = player.getDemonMarks();
+        player.sendMessage("Demon Hunter Level: " + level);
+        player.sendMessage("Task Streak: " + streak);
+        player.sendMessage("Demon Marks: " + marks);
+        player.getDemonContract().ifPresentOrElse(
+                c -> player.sendMessage("Active Contract: Defeat " + c.getAmount() + " " + c.getTarget().getNpcName()),
+                () -> player.sendMessage("Active Contract: none"));
+    }
+
+    private static void openShop(Player player) {
+        DemonMarkRewardHandler.openShop(player);
+    }
+
+    private static void explainTiers(Player player) {
         DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
         for (DemonSlayerMaster.Tier tier : DemonSlayerMaster.Tier.values()) {
             String bosses = Arrays.stream(DemonSlayerMaster.BossTier.values())
@@ -129,16 +161,16 @@ public class DemonHunterSlayerDialogue extends DialogueBuilder {
                     .collect(Collectors.joining(", "));
             builder.npc("Tier " + tier.getId() + " (lvl " + tier.getLevelRequirement() + "): " + bosses);
         }
-        builder.option(new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        builder.option(new DialogueOption("Back", DemonHunterSlayerDialogue::showMainMenu));
         player.start(builder);
     }
 
-    private void explainRewards(Player player) {
+    private static void explainRewards(Player player) {
         DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
         builder.npc("On-task kills grant full Demon Hunter XP and Marks.");
         builder.npc("Off-task kills only award 25% of the base XP and no marks.");
         builder.npc("Higher tiers have larger XP multipliers from the configuration file.");
-        builder.option(new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        builder.option(new DialogueOption("Back", DemonHunterSlayerDialogue::showMainMenu));
         player.start(builder);
     }
 
@@ -146,7 +178,6 @@ public class DemonHunterSlayerDialogue extends DialogueBuilder {
     public static void init() {
         NPCSpawning.spawnNpc(Npcs.DEMON_HUNTER_MASTER, 3095, 3500, 0, 0, 0);
         NPCAction.register(Npcs.DEMON_HUNTER_MASTER, 1,
-                (player, npc) -> player.start(new DemonHunterSlayerDialogue(player)));
+                (player, npc) -> DemonHunterSlayerDialogue.showMainMenu(player));
     }
 }
-

--- a/src/io/xeros/content/skills/slayer/DemonHunterTaskManager.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterTaskManager.java
@@ -25,18 +25,20 @@ public class DemonHunterTaskManager {
             player.setDemonHunterTaskProgress(Math.max(0, remaining));
 
             int xp = DemonHunterXPTable.getXPFor(baseXp, boss.getTier());
-            if (player.getDemonHunterMilestones().contains(10)) {
-                xp = (int) (xp * 1.05);
-            }
             if (player.getDemonContract().isPresent() && !player.getDemonContract().get().isCompleted()
                     && player.getDemonContract().get().matches(boss)) {
                 xp *= 2;
                 player.getDemonContract().get().complete();
-                player.sendMessage("\uD83C\uDFAF Bonus contract complete!");
+                player.addDemonMarks(1);
+                player.sendMessage("\uD83C\uDFAF Contract complete! +2 Demon Marks");
+            }
+            if (player.getDemonTaskStreak() > 10) {
+                xp = (int) (xp * 1.05);
             }
             player.addDemonHunterXP(xp);
             player.getPA().addSkillXPMultiplied(baseXp, Skill.SLAYER.getId(), true);
             DemonSlayerLeaderboardManager.addXp(player, xp);
+            player.addDemonMarks(1);
 
             if (remaining <= 0) {
                 player.sendMessage("\uD83C\uDFAF Task Complete: You've slain " + boss.getNpcName() + "! +" + (xp * player.getDemonHunterTask().get().getAmount()) + " Demon Hunter XP");

--- a/src/io/xeros/content/skills/slayer/DemonSlayerMaster.java
+++ b/src/io/xeros/content/skills/slayer/DemonSlayerMaster.java
@@ -143,7 +143,15 @@ public class DemonSlayerMaster extends SlayerMaster {
             pool = Arrays.asList(BossTier.GENERAL_GRAARDOR);
         }
         BossTier boss = pool.get(Misc.random(pool.size() - 1));
-        int amount = 5 + Misc.random(30); // 5-35
+        int tier = boss.getTier().getId();
+        int amount;
+        if (tier <= 4) {
+            amount = Misc.random(15) + 10; // 10-25
+        } else if (tier <= 7) {
+            amount = Misc.random(10) + 5; // 5-15
+        } else {
+            amount = Misc.random(7) + 3; // 3-10
+        }
         DemonSlayerTask task = new DemonSlayerTask(boss, amount);
         player.setDemonHunterTask(task);
         player.setDemonHunterTaskProgress(amount);


### PR DESCRIPTION
## Summary
- Rework Demon Hunter Slayer dialogue into paginated menus and add admin submenu paging
- Scale task assignment by demon tier for more balanced kill counts
- Grant demon marks on every on-task kill with contract bonuses and streak-based XP boost

## Testing
- `gradle test` *(fails: NoSuchFieldError: JCTree$JCImport)*

------
https://chatgpt.com/codex/tasks/task_e_6896b36c67108320a5a299cd0831c39d