### PR TITLE
Fix AoE instance boundary logic and hazard bounds

### DIFF
--- a/src/io/xeros/content/combat/death/NPCDeath.java
+++ b/src/io/xeros/content/combat/death/NPCDeath.java
@@ -371,6 +371,7 @@ public class NPCDeath {
                     PlayerHandler.executeGlobalMessage(player.getDisplayName() + " has unlocked Tier " + number + " – " + name + "! \uD83D\uDD25");
                 }
             }
+            area.recordKill(player);
             BossInstanceOverlayManager.sendKillOverlay(player);
             InstanceMutatorManager.spikeGlobal(5);
         }

--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -10,6 +10,7 @@ import io.xeros.model.entity.npc.NPCSpawning;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.Position;
+import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.util.Misc;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
@@ -40,6 +41,8 @@ public class BossInstanceManager {
         private final BossTier tier;
         private final io.xeros.content.instances.hazard.EnvironmentalHazardScheduler hazards;
         private final boolean dynamicWaveScaling;
+        /** Tracks consecutive kills per player for killstreak rewards. */
+        private final Map<Player, Integer> killStreaks = new HashMap<>();
 
         BossInstanceArea(Player owner, BossTier tier, Boundary boundary) {
             super(InstanceConfiguration.CLOSE_ON_EMPTY_RESPAWN, owner, boundary);
@@ -83,11 +86,27 @@ public class BossInstanceManager {
         }
 
         public boolean isWithinAoeZone(Position pos) {
-            return true;
+            Boundary boundary = tier.getZoneBoundary();
+            return pos.getHeight() == getHeight()
+                    && pos.getX() >= boundary.getMinimumX() && pos.getX() <= boundary.getMaximumX()
+                    && pos.getY() >= boundary.getMinimumY() && pos.getY() <= boundary.getMaximumY();
         }
 
         public io.xeros.content.instances.hazard.EnvironmentalHazardScheduler getHazardScheduler() {
             return hazards;
+        }
+
+        /** Records a kill for the player and distributes killstreak rewards. */
+        public void recordKill(Player player) {
+            int streak = killStreaks.merge(player, 1, Integer::sum);
+            if (streak % 10 == 0) {
+                TierRewardManager.rewardKillstreak(player, tier, streak);
+            }
+        }
+
+        /** Clears any tracked streak for the supplied player. */
+        public void resetStreak(Player player) {
+            killStreaks.remove(player);
         }
     }
 
@@ -139,11 +158,13 @@ public class BossInstanceManager {
      * the NPCs that can spawn.
      */
     public enum BossTier {
-        TIER1("Training Grounds", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 0, 0, -1, 5, Npcs.COW, 20,
-                new BossMob[]{new BossMob(Npcs.COW, 10, 1, 1, 5, List.of())},
+        // drops/unicow.yml showcases generous horn and hide drops ideal for beginners.
+        TIER1("Unicow Pasture", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 0, 0, -1, 5, Npcs.UNICOW, 20,
+                new BossMob[]{new BossMob(Npcs.UNICOW, 25, 10, 5, 6, List.of())},
                 new TierCombatProfile(1.0,1.0,1.0,1.0,1.0,List.of())),
-        TIER2("Goblin Camp", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 25, 10_000, -1, 10, Npcs.GOBLIN, 20,
-                new BossMob[]{new BossMob(Npcs.GOBLIN, 15, 5, 5, 5, List.of())},
+        // drops/basilisk.yml offers mid-level gear making it a suitable step up.
+        TIER2("Basilisk Lair", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 25, 10_000, -1, 10, Npcs.BASILISK, 20,
+                new BossMob[]{new BossMob(Npcs.BASILISK, 40, 30, 30, 5, List.of())},
                 new TierCombatProfile(1.1,1.05,1.05,1.05,1.0,List.of())),
         TIER3("Giants' Den", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 75, 100_000, -1, 20, Npcs.HILL_GIANT, 20,
                 new BossMob[]{new BossMob(Npcs.HILL_GIANT, 35, 20, 20, 6, List.of())},
@@ -263,6 +284,9 @@ public class BossInstanceManager {
 
         public TierCombatProfile getCombatProfile() { return combatProfile; }
 
+        /** Multiplier applied to damage dealt by hazards and NPCs in this tier. */
+        public double getDamageMultiplier() { return 1.0 + (ordinal() * 0.1); }
+
         public boolean isDynamicWaveScaling() { return dynamicWaveScaling; }
 
         public int getRequiredKillCountToUnlockNext() {
@@ -356,6 +380,11 @@ public class BossInstanceManager {
         int desiredTotal = Math.max(1, areaTiles / Math.max(1, tier.getDesiredNpcDensity()));
         int baseTotal = Arrays.stream(mobs).mapToInt(BossMob::getCount).sum();
         double ratio = baseTotal > 0 ? Math.max(1.0, (double) desiredTotal / baseTotal) : 1.0;
+        if (tier.ordinal() <= BossTier.TIER4.ordinal()) {
+            ratio *= 1.2;
+        } else if (tier.ordinal() >= BossTier.TIER7.ordinal()) {
+            ratio *= 0.8;
+        }
 
         Position spawnTile = tier.getSpawnTile();
         for (BossMob mob : mobs) {
@@ -441,6 +470,7 @@ public class BossInstanceManager {
         BossInstanceOverlayManager.clear(player);
         BossInstanceArea area = INSTANCES.remove(player);
         if (area != null) {
+            area.resetStreak(player);
             area.dispose();
         }
         InstancePerformanceTracker.InstanceResult result = player.getInstancePerformanceTracker().finish();
@@ -455,6 +485,11 @@ public class BossInstanceManager {
             PerformanceRank rank = PerformanceRank.forScore(result.score);
             if (rank.ordinal() >= PerformanceRank.GOLD.ordinal()) {
                 player.sendMessage("@gre@Achievement unlocked: " + rank.name() + " performer!");
+            }
+            int kills = player.getTierKillCounts().getOrDefault(result.tier, 0);
+            if (kills >= result.tier.getRequiredKillCountToUnlockNext()) {
+                String msg = player.getDisplayName() + " has completed " + getTierDisplayNameSafe(result.tier) + "!";
+                PlayerHandler.nonNullStream().forEach(p -> p.sendMessage(msg));
             }
         }
         player.setPreviewingBossInstance(false);

--- a/src/io/xeros/content/instances/TierRewardManager.java
+++ b/src/io/xeros/content/instances/TierRewardManager.java
@@ -17,4 +17,18 @@ public class TierRewardManager {
         player.getItems().addItem(995, 100_000);
        player.sendMessage("You receive 100,000 coins for completing " + BossInstanceManager.getTierDisplayNameSafe(tier) + ".");
     }
+
+    /** Grants a tier-scaled bonus when a player hits a killstreak milestone. */
+    public static void rewardKillstreak(Player player, BossInstanceManager.BossTier tier, int streak) {
+        int level = streak / 10;
+        int coins = 25_000 * level * (tier.ordinal() + 1);
+        player.getItems().addItem(995, coins);
+        player.sendMessage("@blu@Killstreak " + streak + "! You receive " + coins + " coins.");
+    }
+
+    /** Small reward from direct hazard hits scaled by tier. */
+    public static void rewardHazardDrop(Player player, BossInstanceManager.BossTier tier) {
+        int coins = 500 * (tier.ordinal() + 1);
+        player.getItems().addItem(995, coins);
+    }
 }

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardDefinition.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardDefinition.java
@@ -9,7 +9,9 @@ import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.Position;
+import io.xeros.model.StillGraphic;
 import io.xeros.util.Misc;
+import io.xeros.Server;
 
 public class EnvironmentalHazardDefinition {
 
@@ -40,11 +42,13 @@ public class EnvironmentalHazardDefinition {
         int x = forced != null ? forced.getX() : Misc.random(b.getMinimumX(), b.getMaximumX());
         int y = forced != null ? forced.getY() : Misc.random(b.getMinimumY(), b.getMaximumY());
         Position pos = new Position(x, y, area.getHeight());
-        int scaledDamage = (int) (finalTier.scale(damage) * dmgMod);
-        int scaledDrain = (int) (finalTier.scale(drain) * dmgMod);
-        int scaledStun = (int) (finalTier.scale(stun) * dmgMod);
+        double tierMod = area.getTier().getDamageMultiplier();
+        int scaledDamage = (int) (finalTier.scale(damage) * dmgMod * tierMod);
+        int scaledDrain = (int) (finalTier.scale(drain) * dmgMod * tierMod);
+        int scaledStun = (int) (finalTier.scale(stun) * dmgMod * tierMod);
         HazardContext ctx = new HazardContext(type, finalTier, pos);
         HazardDebugLogger.log(area, "Hazard " + type + " at " + pos);
+        Server.playerHandler.sendStillGfx(new StillGraphic(type.getGfxId(), pos), area);
         if (synergyMsg != null) {
             for (Player p : area.getPlayers()) {
                 p.sendMessage(synergyMsg);

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
@@ -5,6 +5,7 @@ import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Boundary;
 
 /**
  * Simple arena wide hazard patterns. The behaviour here is intentionally
@@ -55,9 +56,13 @@ public class EnvironmentalHazardPattern {
                 }
                 break;
             case CHAOS_RIFT:
+                Boundary b = area.getTier().getZoneBoundary();
                 for (Player p : area.getPlayers()) {
-                    p.getPA().movePlayer(p.getPosition().getX() + io.xeros.util.Misc.random(-1,1),
-                            p.getPosition().getY() + io.xeros.util.Misc.random(-1,1), p.getHeight());
+                    int nx = p.getPosition().getX() + io.xeros.util.Misc.random(-1,1);
+                    int ny = p.getPosition().getY() + io.xeros.util.Misc.random(-1,1);
+                    nx = Math.max(b.getMinimumX(), Math.min(b.getMaximumX(), nx));
+                    ny = Math.max(b.getMinimumY(), Math.min(b.getMaximumY(), ny));
+                    p.getPA().movePlayer(nx, ny, area.getHeight());
                     p.sendMessage("@pur@Chaotic forces warp your position!");
                 }
                 break;

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
@@ -7,10 +7,16 @@ import io.xeros.content.instances.hazard.HazardTier;
 import io.xeros.content.instances.hazard.HazardEffectModifier;
 import io.xeros.content.instances.hazard.WeeklyHazardManager;
 import io.xeros.content.instances.hazard.HazardDebugLogger;
+import io.xeros.content.instances.TierRewardManager;
+import io.xeros.content.combat.Hitmark;
+import io.xeros.model.StillGraphic;
+import io.xeros.Server;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Position;
 import io.xeros.util.Misc;
 
 import java.util.*;
@@ -71,7 +77,8 @@ public class EnvironmentalHazardScheduler {
                             }
                         }
                     }
-                    HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                    Position rand = randomPosition();
+                    HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg, rand);
                     recordLast(def, ctx);
                     InstanceMutatorManager.increaseDanger(5);
                     inProgress = false;
@@ -86,7 +93,8 @@ public class EnvironmentalHazardScheduler {
                                     .filter(h -> h.getType() == weekly.eliteHazard)
                                     .findFirst().orElse(null);
                             if (elite != null) {
-                                elite.activate(area, HazardTier.EXTREME, 1.0, "@red@Elite hazard empowered by global danger!");
+                                Position rand = randomPosition();
+                                elite.activate(area, HazardTier.EXTREME, 1.0, "@red@Elite hazard empowered by global danger!", rand);
                                 InstanceMutatorManager.increaseDanger(10);
                             }
                         }
@@ -105,6 +113,27 @@ public class EnvironmentalHazardScheduler {
                 }
             }, pfreq);
         }
+
+        // Periodic unavoidable pulses that keep players attentive.
+        CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+            @Override
+            public void execute(CycleEventContainer container) {
+                for (Player p : area.getPlayers()) {
+                    Position pos = clampPosition(p.getPosition());
+                    Server.playerHandler.sendStillGfx(new StillGraphic(EnvironmentalHazardType.DIRECT_HIT.getGfxId(), pos), area);
+                    int dmg = (int) Math.max(1, 4 * area.getTier().getDamageMultiplier());
+                    CycleEventHandler.getSingleton().addEvent(p, new CycleEvent() {
+                        @Override
+                        public void execute(CycleEventContainer c) {
+                            p.appendDamage(dmg, Hitmark.HIT);
+                            p.sendMessage("@red@A direct hit strikes you!");
+                            TierRewardManager.rewardHazardDrop(p, area.getTier());
+                            c.stop();
+                        }
+                    }, 2);
+                }
+            }
+        }, 50);
     }
 
     public void stop() {
@@ -141,7 +170,8 @@ public class EnvironmentalHazardScheduler {
                         }
                     }
                 }
-                HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                Position rand = randomPosition();
+                HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg, rand);
                 recordLast(def, ctx);
                 cooldowns.put(trigger, now);
                 InstanceMutatorManager.increaseDanger(7);
@@ -185,7 +215,8 @@ public class EnvironmentalHazardScheduler {
     public boolean replay(EnvironmentalHazardType type) {
         HazardRecord r = lastHazards.get(type);
         if (r == null) return false;
-        r.def.activate(area, r.ctx.getTier(), 1.0, null, r.ctx.getPosition());
+        Position pos = clampPosition(r.ctx.getPosition());
+        r.def.activate(area, r.ctx.getTier(), 1.0, null, pos);
         HazardDebugLogger.log(area, "replay:" + type);
         return true;
     }
@@ -196,5 +227,19 @@ public class EnvironmentalHazardScheduler {
         HazardRecord(EnvironmentalHazardDefinition def, HazardContext ctx) {
             this.def = def; this.ctx = ctx;
         }
+    }
+
+    private Position randomPosition() {
+        Boundary b = area.getTier().getZoneBoundary();
+        int x = Misc.random(b.getMinimumX(), b.getMaximumX());
+        int y = Misc.random(b.getMinimumY(), b.getMaximumY());
+        return clampPosition(new Position(x, y, area.getHeight()));
+    }
+
+    private Position clampPosition(Position pos) {
+        Boundary b = area.getTier().getZoneBoundary();
+        int x = Math.max(b.getMinimumX(), Math.min(b.getMaximumX(), pos.getX()));
+        int y = Math.max(b.getMinimumY(), Math.min(b.getMaximumY(), pos.getY()));
+        return new Position(x, y, area.getHeight());
     }
 }

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardType.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardType.java
@@ -1,7 +1,18 @@
 package io.xeros.content.instances.hazard;
 
 public enum EnvironmentalHazardType {
-    FIRE_TILE,
-    POISON_MIST,
-    CRUMBLING_FLOOR
+    FIRE_TILE(502),
+    POISON_MIST(110),
+    CRUMBLING_FLOOR(60),
+    DIRECT_HIT(157);
+
+    private final int gfxId;
+
+    EnvironmentalHazardType(int gfxId) {
+        this.gfxId = gfxId;
+    }
+
+    public int getGfxId() {
+        return gfxId;
+    }
 }

--- a/src/io/xeros/model/entity/npc/NPC.java
+++ b/src/io/xeros/model/entity/npc/NPC.java
@@ -524,6 +524,9 @@ public class NPC extends Entity implements IHazardReactive {
     }
 
     public int modifyDamage(Player player, int damage) {
+        if (player.getInstance() instanceof io.xeros.content.instances.BossInstanceManager.BossInstanceArea area) {
+            damage = (int) Math.max(1, damage * area.getTier().getDamageMultiplier());
+        }
         return damage;
     }
 

--- a/src/test/java/io/xeros/content/instances/BossTierDamageTest.java
+++ b/src/test/java/io/xeros/content/instances/BossTierDamageTest.java
@@ -1,0 +1,15 @@
+package io.xeros.content.instances;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BossTierDamageTest {
+
+    @Test
+    public void damageScalingIncreasesWithTier() {
+        assertTrue(BossInstanceManager.BossTier.TIER1.getDamageMultiplier() <
+                BossInstanceManager.BossTier.TIER2.getDamageMultiplier());
+        assertTrue(BossInstanceManager.BossTier.TIER5.getDamageMultiplier() <
+                BossInstanceManager.BossTier.TIER10.getDamageMultiplier());
+    }
+}


### PR DESCRIPTION
## Summary
- Track killstreaks in AoE instances and award tier-scaled bonuses
- Scale hazard and NPC damage per tier with periodic direct-hit pulses
- Rebalance early tiers to start with Unicows and Basilisks using drop data

## Testing
- `gradle test` *(fails: package org.junit.jupiter.api does not exist; NoSuchFieldError: JCImport qualid)*

------
https://chatgpt.com/codex/tasks/task_e_6896b12cc3d88320be53ac720ea302e8