### PR TITLE
Refactor Demon Hunter Slayer dialogue and rewards

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ sourceSets {
     main {
         java {
             srcDir 'src'
+            exclude 'test/**'
         }
         resources {
             srcDir 'resources'

--- a/src/io/xeros/content/combat/core/HitDispatcher.java
+++ b/src/io/xeros/content/combat/core/HitDispatcher.java
@@ -35,6 +35,7 @@ import io.xeros.content.items.aoeweapons.AoeWeapons;
 import io.xeros.content.minigames.pest_control.PestControl;
 import io.xeros.content.prestige.PrestigePerks;
 import io.xeros.content.skills.Skill;
+import io.xeros.content.skills.slayer.DemonHunterPerks;
 import io.xeros.content.tournaments.TourneyManager;
 import io.xeros.model.*;
 import io.xeros.model.cycleevent.CycleEvent;
@@ -278,8 +279,15 @@ public abstract class HitDispatcher {
                 }
             }
 
-            if (attacker.bonusDmg) {
-                damage = (int) (damage + (damage * 0.20));
+             if (attacker.bonusDmg) {
+                 damage = (int) (damage + (damage * 0.20));
+             }
+
+            if (defender.isNPC()) {
+                double bonus = DemonHunterPerks.getDamageBonus(attacker, defender.asNPC());
+                if (bonus > 0) {
+                    damage = (int) (damage + damage * bonus);
+                }
             }
 
             if (attacker.dailyDamage > 0) {
@@ -439,6 +447,13 @@ public abstract class HitDispatcher {
 
             if (attacker.bonusDmg) {
                 maximumDamage *= 1.20;
+            }
+
+            if (defender.isNPC()) {
+                double bonus = DemonHunterPerks.getDamageBonus(attacker, defender.asNPC());
+                if (bonus > 0) {
+                    maximumDamage *= 1 + bonus;
+                }
             }
             if (attacker.dailyDamage > 0) {
                 maximumDamage *= 1.10;
@@ -640,6 +655,13 @@ public abstract class HitDispatcher {
 
             if (attacker.bonusDmg) {
                 damage *= 1.20;
+            }
+
+            if (defender.isNPC()) {
+                double bonus = DemonHunterPerks.getDamageBonus(attacker, defender.asNPC());
+                if (bonus > 0) {
+                    damage *= 1 + bonus;
+                }
             }
 
             if (attacker.dailyDamage > 0) {

--- a/src/io/xeros/content/skills/slayer/DemonHunterPerks.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterPerks.java
@@ -1,0 +1,73 @@
+package io.xeros.content.skills.slayer;
+
+import io.xeros.content.skills.Skill;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.player.Player;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Perks unlocked by leveling the Demon Hunter skill.
+ */
+public class DemonHunterPerks {
+
+    /** Perk definitions with unlock level and short description. */
+    public enum Perk {
+        DROP_RATE(20, "Drop Rate +5%"),
+        FAST_TRACK(40, "Faster Tasks"),
+        MARK_MASTER(60, "+1 Mark/kill");
+
+        private final int level;
+        private final String description;
+
+        Perk(int level, String description) {
+            this.level = level;
+            this.description = description;
+        }
+
+        public int getLevel() {
+            return level;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public boolean isUnlocked(int currentLevel) {
+            return currentLevel >= level;
+        }
+    }
+
+    /** Returns true if the player has unlocked the given perk. */
+    public static boolean has(Player player, Perk perk) {
+        int level = player.getLevel(Skill.DEMON_HUNTER);
+        return perk.isUnlocked(level);
+    }
+
+    /** Lists descriptions of perks unlocked at the player's current level. */
+    public static String unlockedDescriptions(Player player) {
+        int level = player.getLevel(Skill.DEMON_HUNTER);
+        List<String> list = Arrays.stream(Perk.values())
+                .filter(p -> p.isUnlocked(level))
+                .map(Perk::getDescription)
+                .collect(Collectors.toList());
+        return String.join(", ", list);
+    }
+
+    /**
+     * Damage bonus based on Demon Hunter level when fighting the assigned boss.
+     *
+     * @return fractional bonus (0.10 = +10% damage)
+     */
+    public static double getDamageBonus(Player player, NPC npc) {
+        Optional<DemonSlayerMaster.DemonSlayerTask> task = player.getDemonHunterTask();
+        if (task.isPresent() && npc != null && npc.getNpcId() == task.get().getBoss().getNpcId()) {
+            int level = player.getLevel(Skill.DEMON_HUNTER);
+            return level * 0.01;
+        }
+        return 0.0;
+    }
+}

--- a/src/io/xeros/content/skills/slayer/DemonHunterSlayerDialogue.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterSlayerDialogue.java
@@ -19,75 +19,59 @@ import java.util.stream.Collectors;
 /**
  * Dialogue interface for the Demon Hunter Slayer Master NPC.
  */
-public class DemonHunterSlayerDialogue extends DialogueBuilder {
+public class DemonHunterSlayerDialogue {
 
     private static final int NPC = Npcs.DEMON_HUNTER_MASTER;
 
-    public DemonHunterSlayerDialogue(Player player) {
-        super(player);
-        setNpcId(NPC);
-        npc("Greetings, slayer. How can I assist you on your Demon Hunter journey?");
-        List<DialogueOption> options = new ArrayList<>();
-        options.add(new DialogueOption("What's Demon Hunter Slayer?", this::explainSystem));
-        options.add(new DialogueOption("What are the Demon Hunter Slayer tiers?", this::explainTiers));
-        options.add(new DialogueOption("What are the rewards and XP like?", this::explainRewards));
-        options.add(new DialogueOption("View Current Task", this::viewTask));
-        options.add(new DialogueOption("Abandon Task", this::abandonTask));
-        options.add(new DialogueOption("View Stats / Contract", this::viewStats));
-        options.add(new DialogueOption("Open Reward Shop", this::openShop));
-        if (player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
-            options.add(new DialogueOption("Admin Options", this::adminMenu));
-        }
-        option(options.toArray(new DialogueOption[0]));
+    /**
+     * Opens the main Demon Hunter menu.
+     */
+    public static void showMainMenu(Player player) {
+        showMainMenu(player, true);
     }
 
-    private void explainSystem(Player player) {
+    private static void showMainMenu(Player player, boolean greet) {
         DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
-        builder.npc("Demon Hunter Slayer is an elite slayer mode focused on defeating demon bosses.");
-        builder.npc("You'll receive powerful assignments based on your Demon Hunter level.");
-        builder.npc("Progress builds your streak, earns Slayer XP, and rewards Demon Marks.");
-        builder.npc("Milestones unlock perks and elite tasks, and contracts offer extra rewards.");
-        builder.npc("Track your progress, climb the leaderboard, and claim your glory.");
-        builder.option(new DialogueOption("Got it. Back to menu.", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        if (greet) {
+            builder.npc("Greetings, slayer. Need help with demon hunts?");
+        }
+
+        List<DialogueOption> options = new ArrayList<>();
+        options.add(new DialogueOption("What's Demon Hunter Slayer?", DemonHunterSlayerDialogue::explainSystem));
+        options.add(new DialogueOption("What are the Demon tiers?", DemonHunterSlayerDialogue::explainTiers));
+        options.add(new DialogueOption("Rewards and XP?", DemonHunterSlayerDialogue::explainRewards));
+        options.add(new DialogueOption("Task Menu", DemonHunterSlayerDialogue::showTaskMenu));
+        if (player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
+            options.add(new DialogueOption("Admin Options", DemonHunterSlayerDialogue::showAdminMenu));
+        }
+        builder.option(options.toArray(new DialogueOption[0]));
         player.start(builder);
     }
 
-    private void viewTask(Player player) {
-        if (player.getDemonHunterTask().isEmpty()) {
-            player.sendMessage("You don't currently have a Demon Hunter task.");
-            return;
-        }
-        DemonHunterTaskOverlayManager.schedule(player);
-        player.sendMessage("Your task overlay has been refreshed.");
+    /**
+     * Opens the task management submenu.
+     */
+    public static void showTaskMenu(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.option(
+                new DialogueOption("View Current Task", p -> {
+                    if (p.getDemonHunterTask().isEmpty()) {
+                        new DemonSlayerMaster().assign(p);
+                    }
+                    viewTask(p);
+                }),
+                new DialogueOption("Abandon Task", DemonHunterSlayerDialogue::abandonTask),
+                new DialogueOption("View Stats / Contract", DemonHunterSlayerDialogue::viewStats),
+                new DialogueOption("Open Reward Shop", DemonHunterSlayerDialogue::openShop),
+                new DialogueOption("Back", p -> showMainMenu(p, false))
+        );
+        player.start(builder);
     }
 
-    private void abandonTask(Player player) {
-        if (player.getDemonHunterTask().isEmpty()) {
-            player.sendMessage("You don't have a task to abandon.");
-            return;
-        }
-        player.sendMessage("You have abandoned your current task.");
-        player.setDemonHunterTask(null);
-        player.setDemonHunterTaskProgress(0);
-    }
-
-    private void viewStats(Player player) {
-        int level = player.playerLevel[Skill.DEMON_HUNTER.getId()];
-        int streak = player.getDemonTaskStreak();
-        int marks = player.getDemonMarks();
-        player.sendMessage("Demon Hunter Level: " + level);
-        player.sendMessage("Task Streak: " + streak);
-        player.sendMessage("Demon Marks: " + marks);
-        player.getDemonContract().ifPresentOrElse(
-                c -> player.sendMessage("Active Contract: Defeat " + c.getAmount() + " " + c.getTarget().getNpcName()),
-                () -> player.sendMessage("Active Contract: none"));
-    }
-
-    private void openShop(Player player) {
-        DemonMarkRewardHandler.openShop(player);
-    }
-
-    private void adminMenu(Player player) {
+    /**
+     * Opens the administrator submenu (page 1).
+     */
+    public static void showAdminMenu(Player player) {
         if (!player.getRights().isOrInherits(Right.ADMINISTRATOR)) {
             player.sendMessage("Only admins can access this.");
             return;
@@ -109,6 +93,17 @@ public class DemonHunterSlayerDialogue extends DialogueBuilder {
                     p.setDemonContract(null);
                     p.sendMessage("Contract cleared.");
                 }),
+                new DialogueOption("More Options", DemonHunterSlayerDialogue::showAdminMenuMore)
+        );
+        player.start(builder);
+    }
+
+    /**
+     * Additional administrator options (page 2).
+     */
+    private static void showAdminMenuMore(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.option(
                 new DialogueOption("View boss XP logs", p -> {
                     for (DemonSlayerMaster.BossTier bt : DemonSlayerMaster.BossTier.values()) {
                         int xp = DemonHunterXPTable.getXPFor(bt.getBaseXp(), bt.getTier());
@@ -116,29 +111,85 @@ public class DemonHunterSlayerDialogue extends DialogueBuilder {
                     }
                 }),
                 new DialogueOption("Open Reward Shop", DemonMarkRewardHandler::openShop),
-                new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+                new DialogueOption("Back", p -> showMainMenu(p, false)),
+                new DialogueOption("Previous", DemonHunterSlayerDialogue::showAdminMenu)
+        );
         player.start(builder);
     }
 
-    private void explainTiers(Player player) {
+    private static void explainSystem(Player player) {
+        DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
+        builder.npc("Demon Hunter is an elite mode", "focused on demon bosses.");
+        builder.npc("Assignments scale with your level", "and grant Demon Marks.");
+        builder.npc("Milestones unlock perks and tasks", "while contracts add bonuses.");
+        builder.option(
+                new DialogueOption("Back to menu", p -> showMainMenu(p, false)),
+                DialogueBuilder.EXIT_DIALOGUE_OPTION
+        );
+        player.start(builder);
+    }
+
+    private static void viewTask(Player player) {
+        if (player.getDemonHunterTask().isEmpty()) {
+            player.sendMessage("You don't currently have a Demon Hunter task.");
+            return;
+        }
+        DemonHunterTaskOverlayManager.schedule(player);
+        player.sendMessage("Your task overlay has been refreshed.");
+    }
+
+    private static void abandonTask(Player player) {
+        if (player.getDemonHunterTask().isEmpty()) {
+            player.sendMessage("You don't have a task to abandon.");
+            return;
+        }
+        player.sendMessage("You have abandoned your current task.");
+        player.setDemonHunterTask(null);
+        player.setDemonHunterTaskProgress(0);
+    }
+
+    private static void viewStats(Player player) {
+        int level = player.playerLevel[Skill.DEMON_HUNTER.getId()];
+        int streak = player.getDemonTaskStreak();
+        int marks = player.getDemonMarks();
+        player.sendMessage("Demon Hunter Level: " + level);
+        player.sendMessage("Task Streak: " + streak);
+        player.sendMessage("Demon Marks: " + marks);
+        player.getDemonContract().ifPresentOrElse(
+                c -> player.sendMessage("Active Contract: Defeat " + c.getAmount() + " " + c.getTarget().getNpcName()),
+                () -> player.sendMessage("Active Contract: none"));
+    }
+
+    private static void openShop(Player player) {
+        DemonMarkRewardHandler.openShop(player);
+    }
+
+    private static void explainTiers(Player player) {
         DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
         for (DemonSlayerMaster.Tier tier : DemonSlayerMaster.Tier.values()) {
             String bosses = Arrays.stream(DemonSlayerMaster.BossTier.values())
                     .filter(b -> b.getTier() == tier)
                     .map(DemonSlayerMaster.BossTier::getNpcName)
                     .collect(Collectors.joining(", "));
-            builder.npc("Tier " + tier.getId() + " (lvl " + tier.getLevelRequirement() + "): " + bosses);
+            builder.npc("Tier " + tier.getId() + " (lvl " + tier.getLevelRequirement() + "):", bosses);
         }
-        builder.option(new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        builder.option(
+                new DialogueOption("Back to menu", p -> showMainMenu(p, false)),
+                DialogueBuilder.EXIT_DIALOGUE_OPTION
+        );
         player.start(builder);
     }
 
-    private void explainRewards(Player player) {
+    private static void explainRewards(Player player) {
         DialogueBuilder builder = new DialogueBuilder(player).setNpcId(NPC);
-        builder.npc("On-task kills grant full Demon Hunter XP and Marks.");
-        builder.npc("Off-task kills only award 25% of the base XP and no marks.");
-        builder.npc("Higher tiers have larger XP multipliers from the configuration file.");
-        builder.option(new DialogueOption("Back", p -> p.start(new DemonHunterSlayerDialogue(p))));
+        builder.npc("On-task kills give full XP", "and Demon Marks.");
+        builder.npc("Each Demon Hunter level", "adds +1% task damage.");
+        builder.npc("Lvl20: +5% drops, Lvl40:", "faster kills, Lvl60: +1 mark");
+        builder.npc("Off-task kills give 25%", "base XP and no marks.");
+        builder.option(
+                new DialogueOption("Back to menu", p -> showMainMenu(p, false)),
+                DialogueBuilder.EXIT_DIALOGUE_OPTION
+        );
         player.start(builder);
     }
 
@@ -146,7 +197,6 @@ public class DemonHunterSlayerDialogue extends DialogueBuilder {
     public static void init() {
         NPCSpawning.spawnNpc(Npcs.DEMON_HUNTER_MASTER, 3095, 3500, 0, 0, 0);
         NPCAction.register(Npcs.DEMON_HUNTER_MASTER, 1,
-                (player, npc) -> player.start(new DemonHunterSlayerDialogue(player)));
+                (player, npc) -> DemonHunterSlayerDialogue.showMainMenu(player, true));
     }
 }
-

--- a/src/io/xeros/content/skills/slayer/DemonHunterTaskManager.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterTaskManager.java
@@ -4,6 +4,9 @@ import io.xeros.content.skills.Skill;
 import io.xeros.model.entity.npc.NPC;
 import io.xeros.model.entity.player.Player;
 
+import static io.xeros.content.skills.slayer.DemonHunterPerks.Perk;
+import io.xeros.content.skills.slayer.DemonHunterPerks;
+
 import java.util.Optional;
 
 /**
@@ -21,22 +24,28 @@ public class DemonHunterTaskManager {
         int baseXp = boss.getBaseXp();
 
         if (player.getDemonHunterTask().isPresent() && player.getDemonHunterTask().get().getBoss() == boss) {
-            int remaining = player.getDemonHunterTaskProgress() - 1;
+            int decrement = DemonHunterPerks.has(player, Perk.FAST_TRACK) ? 2 : 1;
+            int remaining = player.getDemonHunterTaskProgress() - decrement;
             player.setDemonHunterTaskProgress(Math.max(0, remaining));
 
             int xp = DemonHunterXPTable.getXPFor(baseXp, boss.getTier());
-            if (player.getDemonHunterMilestones().contains(10)) {
-                xp = (int) (xp * 1.05);
-            }
             if (player.getDemonContract().isPresent() && !player.getDemonContract().get().isCompleted()
                     && player.getDemonContract().get().matches(boss)) {
                 xp *= 2;
                 player.getDemonContract().get().complete();
-                player.sendMessage("\uD83C\uDFAF Bonus contract complete!");
+                player.addDemonMarks(1);
+                player.sendMessage("\uD83C\uDFAF Contract complete! +2 Demon Marks");
+            }
+            if (player.getDemonTaskStreak() > 10) {
+                xp = (int) (xp * 1.05);
             }
             player.addDemonHunterXP(xp);
             player.getPA().addSkillXPMultiplied(baseXp, Skill.SLAYER.getId(), true);
             DemonSlayerLeaderboardManager.addXp(player, xp);
+            player.addDemonMarks(1);
+            if (DemonHunterPerks.has(player, Perk.MARK_MASTER)) {
+                player.addDemonMarks(1);
+            }
 
             if (remaining <= 0) {
                 player.sendMessage("\uD83C\uDFAF Task Complete: You've slain " + boss.getNpcName() + "! +" + (xp * player.getDemonHunterTask().get().getAmount()) + " Demon Hunter XP");

--- a/src/io/xeros/content/skills/slayer/DemonHunterTaskOverlayManager.java
+++ b/src/io/xeros/content/skills/slayer/DemonHunterTaskOverlayManager.java
@@ -1,6 +1,7 @@
 package io.xeros.content.skills.slayer;
 
 import io.xeros.content.skills.Skill;
+import io.xeros.content.skills.slayer.DemonHunterPerks;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
@@ -24,6 +25,12 @@ public class DemonHunterTaskOverlayManager {
             player.sendMessage("Kills Left: " + player.getDemonHunterTaskProgress());
             player.sendMessage("XP per kill: " + xp);
             player.sendMessage("Streak: " + player.getDemonTaskStreak() + " | Marks: " + player.getDemonMarks());
+            int level = player.getLevel(Skill.DEMON_HUNTER);
+            player.sendMessage("Damage Bonus: +" + level + "%");
+            String perks = DemonHunterPerks.unlockedDescriptions(player);
+            if (!perks.isEmpty()) {
+                player.sendMessage("Perks: " + perks);
+            }
             player.getDemonContract().ifPresent(c -> player.sendMessage("\uD83C\uDFAF Bonus: Defeat " + c.getTarget().getNpcName() + " for 2x XP"));
             DemonSlayerMaster.Tier.forId(player.getDemonHunterTierUnlocked() + 1).ifPresent(t -> {
                 String bosses = Arrays.stream(DemonSlayerMaster.BossTier.values())

--- a/src/io/xeros/content/skills/slayer/DemonSlayerMaster.java
+++ b/src/io/xeros/content/skills/slayer/DemonSlayerMaster.java
@@ -143,7 +143,15 @@ public class DemonSlayerMaster extends SlayerMaster {
             pool = Arrays.asList(BossTier.GENERAL_GRAARDOR);
         }
         BossTier boss = pool.get(Misc.random(pool.size() - 1));
-        int amount = 5 + Misc.random(30); // 5-35
+        int tier = boss.getTier().getId();
+        int amount;
+        if (tier <= 4) {
+            amount = Misc.random(15) + 10; // 10-25
+        } else if (tier <= 7) {
+            amount = Misc.random(10) + 5; // 5-15
+        } else {
+            amount = Misc.random(7) + 3; // 3-10
+        }
         DemonSlayerTask task = new DemonSlayerTask(boss, amount);
         player.setDemonHunterTask(task);
         player.setDemonHunterTaskProgress(amount);

--- a/src/io/xeros/model/entity/npc/drops/DropManager.java
+++ b/src/io/xeros/model/entity/npc/drops/DropManager.java
@@ -49,6 +49,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.xeros.content.skills.slayer.DemonHunterPerks;
 
 import java.io.File;
 import java.io.IOException;
@@ -491,6 +492,7 @@ public class DropManager {
         final List<GameItem> perkItems = perkSystem.gameItems;
         if (perkItems.contains(GameItem.get(33112))) modifier += 0.20D;
         if (perkItems.contains(GameItem.get(33108))) modifier += 0.10D;
+        if (DemonHunterPerks.has(player, DemonHunterPerks.Perk.DROP_RATE)) modifier += 0.05D;
 
         // Game modes
         if (player.experienceModeEquals(ExpModeType.OneTimes)) modifier += 0.20D;

--- a/src/test/java/DemonHunterPerksTest.java
+++ b/src/test/java/DemonHunterPerksTest.java
@@ -1,0 +1,42 @@
+import io.xeros.content.skills.slayer.DemonHunterPerks;
+import io.xeros.content.skills.slayer.DemonSlayerMaster;
+import io.xeros.content.skills.Skill;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.npc.NPC;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class DemonHunterPerksTest {
+
+    @Test
+    void unlocksBasedOnLevel() {
+        Player player = mock(Player.class);
+        when(player.getLevel(Skill.DEMON_HUNTER)).thenReturn(40);
+
+        assertTrue(DemonHunterPerks.has(player, DemonHunterPerks.Perk.DROP_RATE));
+        assertTrue(DemonHunterPerks.has(player, DemonHunterPerks.Perk.FAST_TRACK));
+        assertFalse(DemonHunterPerks.has(player, DemonHunterPerks.Perk.MARK_MASTER));
+    }
+
+    @Test
+    void damageBonusMatchesLevelAndTask() {
+        Player player = mock(Player.class);
+        NPC npc = mock(NPC.class);
+
+        DemonSlayerMaster.BossTier boss = DemonSlayerMaster.BossTier.GENERAL_GRAARDOR;
+        DemonSlayerMaster.DemonSlayerTask task = new DemonSlayerMaster.DemonSlayerTask(boss, 5);
+
+        when(player.getDemonHunterTask()).thenReturn(Optional.of(task));
+        when(player.getLevel(Skill.DEMON_HUNTER)).thenReturn(50);
+        when(npc.getNpcId()).thenReturn(boss.getNpcId());
+
+        assertEquals(0.50, DemonHunterPerks.getDamageBonus(player, npc), 0.0001);
+
+        when(npc.getNpcId()).thenReturn(999);
+        assertEquals(0.0, DemonHunterPerks.getDamageBonus(player, npc), 0.0001);
+    }
+}

--- a/src/test/java/DemonHunterSlayerDialogueTest.java
+++ b/src/test/java/DemonHunterSlayerDialogueTest.java
@@ -1,0 +1,107 @@
+import io.xeros.content.dialogue.DialogueBuilder;
+import io.xeros.content.dialogue.DialogueOption;
+import io.xeros.content.dialogue.DialogueAction;
+import io.xeros.content.dialogue.types.OptionDialogue;
+import io.xeros.content.dialogue.DialogueObject;
+import io.xeros.content.skills.slayer.DemonHunterSlayerDialogue;
+import io.xeros.content.skills.slayer.DemonHunterTaskOverlayManager;
+import io.xeros.content.skills.slayer.DemonSlayerMaster;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class DemonHunterSlayerDialogueTest {
+
+    @Test
+    void backToMenuDisplaysAndReturns() throws Exception {
+        Player player = mock(Player.class);
+        when(player.getRights()).thenReturn(Right.PLAYER);
+
+        ArgumentCaptor<DialogueBuilder> captor = ArgumentCaptor.forClass(DialogueBuilder.class);
+        DemonHunterSlayerDialogue.showMainMenu(player);
+        verify(player).start(captor.capture());
+        DialogueBuilder main = captor.getValue();
+
+        clearInvocations(player);
+        main.dispatchAction(DialogueAction.OPTION_1);
+        verify(player).start(captor.capture());
+        DialogueBuilder explain = captor.getValue();
+
+        OptionDialogue backDialogue = (OptionDialogue) getLastDialogue(explain);
+        List<String> titles = getOptionTitles(backDialogue);
+        assertEquals("Back to menu", titles.get(0));
+        assertEquals("Exit", titles.get(1));
+        assertFalse(titles.contains("option2"));
+
+        clearInvocations(player);
+        explain.dispatchAction(DialogueAction.OPTION_1);
+        verify(player).start(captor.capture());
+        DialogueBuilder afterBack = captor.getValue();
+
+        OptionDialogue mainMenu = (OptionDialogue) getLastDialogue(afterBack);
+        List<String> mainTitles = getOptionTitles(mainMenu);
+        assertTrue(mainTitles.contains("What's Demon Hunter Slayer?"));
+    }
+
+    @Test
+    void viewTaskAssignsWhenMissing() throws Exception {
+        Player player = mock(Player.class);
+        when(player.getRights()).thenReturn(Right.PLAYER);
+        DemonSlayerMaster.DemonSlayerTask task = mock(DemonSlayerMaster.DemonSlayerTask.class);
+        when(player.getDemonHunterTask()).thenReturn(Optional.empty(), Optional.of(task));
+
+        try (MockedConstruction<DemonSlayerMaster> cons = mockConstruction(DemonSlayerMaster.class,
+                (mock, context) -> when(mock.assign(any())).thenReturn(task));
+             MockedStatic<DemonHunterTaskOverlayManager> overlay = mockStatic(DemonHunterTaskOverlayManager.class)) {
+
+            ArgumentCaptor<DialogueBuilder> captor = ArgumentCaptor.forClass(DialogueBuilder.class);
+            DemonHunterSlayerDialogue.showTaskMenu(player);
+            verify(player).start(captor.capture());
+            DialogueBuilder menu = captor.getValue();
+
+            OptionDialogue options = (OptionDialogue) getLastDialogue(menu);
+            DialogueOption[] opts = getOptions(options);
+            opts[0].getConsumer().accept(player);
+
+            DemonSlayerMaster constructed = cons.constructed().get(0);
+            verify(constructed).assign(player);
+            overlay.verify(() -> DemonHunterTaskOverlayManager.schedule(player));
+            verify(player, never()).sendMessage("You don't currently have a Demon Hunter task.");
+        }
+    }
+
+    private static DialogueObject getLastDialogue(DialogueBuilder builder) throws Exception {
+        Field rootField = DialogueBuilder.class.getDeclaredField("root");
+        rootField.setAccessible(true);
+        DialogueObject current = (DialogueObject) rootField.get(builder);
+        while (current.getChild() != null) {
+            current = current.getChild();
+        }
+        return current;
+    }
+
+    private static List<String> getOptionTitles(OptionDialogue dialogue) throws Exception {
+        Field optionsField = OptionDialogue.class.getDeclaredField("options");
+        optionsField.setAccessible(true);
+        DialogueOption[] options = (DialogueOption[]) optionsField.get(dialogue);
+        return Arrays.stream(options).map(DialogueOption::getTitle).collect(Collectors.toList());
+    }
+
+    private static DialogueOption[] getOptions(OptionDialogue dialogue) throws Exception {
+        Field optionsField = OptionDialogue.class.getDeclaredField("options");
+        optionsField.setAccessible(true);
+        return (DialogueOption[]) optionsField.get(dialogue);
+    }
+}


### PR DESCRIPTION
## Summary
- Rework Demon Hunter Slayer dialogue into paginated menus and add admin submenu paging
- Scale task assignment by demon tier for more balanced kill counts
- Grant demon marks on every on-task kill with contract bonuses and streak-based XP boost
- Unlock Demon Hunter level perks providing drop-rate boosts, faster tasks, extra marks, and per-level damage scaling
- Fix back-to-menu option so explanatory pages return to the main menu and offer a clean exit
- Auto-assign a Demon Hunter task when players view tasks without one and cover the behavior in tests

## Testing
- `gradle test` *(fails: java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid')*

------
https://chatgpt.com/codex/tasks/task_e_6896b36c67108320a5a299cd0831c39d