### PR TITLE
Fix AoE instance boundary logic and hazard bounds

### DIFF
--- a/src/io/xeros/content/combat/death/NPCDeath.java
+++ b/src/io/xeros/content/combat/death/NPCDeath.java
@@ -22,6 +22,7 @@ import io.xeros.content.combat.Hitmark;
 import io.xeros.content.event.eventcalendar.EventChallenge;
 import io.xeros.content.events.monsterhunt.MonsterHunt;
 import io.xeros.content.instances.TierRewardManager;
+import io.xeros.content.items.aoeweapons.AoeManager;
 import io.xeros.content.minigames.warriors_guild.AnimatedArmour;
 import io.xeros.content.skills.Skill;
 import io.xeros.content.skills.hunter.impling.ItemRarity;
@@ -370,6 +371,12 @@ public class NPCDeath {
                     player.sendMessage("<col=ff00ff><shad=000000>\uD83C\uDF89 You’ve unlocked Tier " + number + ": " + name + "!</col>");
                     PlayerHandler.executeGlobalMessage(player.getDisplayName() + " has unlocked Tier " + number + " – " + name + "! \uD83D\uDD25");
                 }
+            }
+            area.recordKill(player);
+            if (AoeManager.canAOE(player)) {
+                area.recordAoeKill(player);
+            } else {
+                area.resetAoeStreak(player);
             }
             BossInstanceOverlayManager.sendKillOverlay(player);
             InstanceMutatorManager.spikeGlobal(5);

--- a/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
@@ -57,7 +57,18 @@ public class BossInstanceDialogue extends DialogueBuilder {
         Player player = getPlayer();
         BossTier[] tiers = BossTier.values();
 
-        int startIndex = page * OPTIONS_PER_PAGE;
+        // First page can show four tiers (one slot reserved for "More"),
+        // subsequent pages show three tiers because both navigation options
+        // may be present. Compute the starting index accordingly so tiers
+        // are not skipped.
+        int startIndex;
+        if (page == 0) {
+            startIndex = 0;
+        } else {
+            int firstPageCount = OPTIONS_PER_PAGE - 1; // 4 tiers on page 0
+            int subsequentPageCount = OPTIONS_PER_PAGE - 2; // 3 tiers when back+more are shown
+            startIndex = firstPageCount + (page - 1) * subsequentPageCount;
+        }
 
         displayed.clear();
 

--- a/src/io/xeros/content/instances/BossInstanceManager.java
+++ b/src/io/xeros/content/instances/BossInstanceManager.java
@@ -10,6 +10,7 @@ import io.xeros.model.entity.npc.NPCSpawning;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.Position;
+import io.xeros.model.entity.player.PlayerHandler;
 import io.xeros.util.Misc;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
@@ -40,6 +41,10 @@ public class BossInstanceManager {
         private final BossTier tier;
         private final io.xeros.content.instances.hazard.EnvironmentalHazardScheduler hazards;
         private final boolean dynamicWaveScaling;
+        /** Tracks consecutive kills per player for killstreak rewards. */
+        private final Map<Player, Integer> killStreaks = new HashMap<>();
+        /** Tracks consecutive AoE kills for bonus rewards. */
+        private final Map<Player, Integer> aoeStreaks = new HashMap<>();
 
         BossInstanceArea(Player owner, BossTier tier, Boundary boundary) {
             super(InstanceConfiguration.CLOSE_ON_EMPTY_RESPAWN, owner, boundary);
@@ -83,11 +88,40 @@ public class BossInstanceManager {
         }
 
         public boolean isWithinAoeZone(Position pos) {
-            return true;
+            Boundary boundary = tier.getZoneBoundary();
+            return pos.getHeight() == getHeight()
+                    && pos.getX() >= boundary.getMinimumX() && pos.getX() <= boundary.getMaximumX()
+                    && pos.getY() >= boundary.getMinimumY() && pos.getY() <= boundary.getMaximumY();
         }
 
         public io.xeros.content.instances.hazard.EnvironmentalHazardScheduler getHazardScheduler() {
             return hazards;
+        }
+
+        /** Records a kill for the player and distributes killstreak rewards. */
+        public void recordKill(Player player) {
+            int streak = killStreaks.merge(player, 1, Integer::sum);
+            if (streak % 10 == 0) {
+                TierRewardManager.rewardKillstreak(player, tier, streak);
+            }
+        }
+
+        /** Records an AoE kill for bonus streak rewards. */
+        public void recordAoeKill(Player player) {
+            int streak = aoeStreaks.merge(player, 1, Integer::sum);
+            if (streak % 5 == 0) {
+                TierRewardManager.rewardAoeKillstreak(player, tier, streak);
+            }
+        }
+
+        /** Clears any tracked streaks for the supplied player. */
+        public void resetStreak(Player player) {
+            killStreaks.remove(player);
+            aoeStreaks.remove(player);
+        }
+        /** Clears only the AoE streak for cases where a normal kill occurs. */
+        public void resetAoeStreak(Player player) {
+            aoeStreaks.remove(player);
         }
     }
 
@@ -139,36 +173,81 @@ public class BossInstanceManager {
      * the NPCs that can spawn.
      */
     public enum BossTier {
-        TIER1("Training Grounds", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 0, 0, -1, 5, Npcs.COW, 20,
-                new BossMob[]{new BossMob(Npcs.COW, 10, 1, 1, 5, List.of())},
-                new TierCombatProfile(1.0,1.0,1.0,1.0,1.0,List.of())),
-        TIER2("Goblin Camp", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 25, 10_000, -1, 10, Npcs.GOBLIN, 20,
-                new BossMob[]{new BossMob(Npcs.GOBLIN, 15, 5, 5, 5, List.of())},
-                new TierCombatProfile(1.1,1.05,1.05,1.05,1.0,List.of())),
-        TIER3("Giants' Den", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 75, 100_000, -1, 20, Npcs.HILL_GIANT, 20,
-                new BossMob[]{new BossMob(Npcs.HILL_GIANT, 35, 20, 20, 6, List.of())},
-                new TierCombatProfile(1.2,1.1,1.1,1.1,1.05,List.of())),
-        TIER4("Moss Cave", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 150, 250_000, -1, 25, Npcs.MOSS_GIANT, 20,
-                new BossMob[]{new BossMob(Npcs.MOSS_GIANT, 60, 40, 40, 6, List.of())},
-                new TierCombatProfile(1.3,1.15,1.15,1.15,1.1,List.of())),
-        TIER5("Fire Pit", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 250, 500_000, -1, 30, Npcs.FIRE_GIANT, 20,
-                new BossMob[]{new BossMob(Npcs.FIRE_GIANT, 80, 60, 60, 7, List.of())},
-                new TierCombatProfile(1.4,1.2,1.2,1.2,1.15,List.of())),
-        TIER6("Green Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 350, 750_000, -1, 35, Npcs.GREEN_DRAGON, 20,
-                new BossMob[]{new BossMob(Npcs.GREEN_DRAGON, 120, 90, 90, 7, List.of())},
-                new TierCombatProfile(1.5,1.25,1.25,1.25,1.2,List.of())),
-        TIER7("Red Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 500, 1_000_000, -1, 40, Npcs.RED_DRAGON, 20,
-                new BossMob[]{new BossMob(Npcs.RED_DRAGON, 150, 110, 110, 8, List.of())},
-                new TierCombatProfile(1.6,1.3,1.3,1.3,1.25,List.of())),
-        TIER8("Black Dragons", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 650, 2_000_000, -1, 45, Npcs.BLACK_DRAGON, 20,
-                new BossMob[]{new BossMob(Npcs.BLACK_DRAGON, 180, 130, 130, 8, List.of())},
-                new TierCombatProfile(1.7,1.35,1.35,1.35,1.3,List.of())),
-        TIER9("Demon Domain", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 800, 3_000_000, -1, 50, Npcs.BLACK_DEMON, 20,
-                new BossMob[]{new BossMob(Npcs.BLACK_DEMON, 200, 150, 150, 9, List.of("infernal_slam"))},
-                new TierCombatProfile(1.8,1.4,1.4,1.4,1.35,List.of("infernal_slam"))),
-        TIER10("Dragon King", new Boundary(2270, 4758, 2295, 4785), new Position(2282, 4770), 1_000, 5_000_000, 11286, 60, Npcs.KING_BLACK_DRAGON, 20,
-                new BossMob[]{new BossMob(Npcs.KING_BLACK_DRAGON, 250, 180, 180, 1, List.of("infernal_slam"))},
-                new TierCombatProfile(2.0,1.5,1.5,1.45,1.4,List.of("infernal_slam")));
+        // drops/unicow.yml and drops/imp.yml supply beginner hides and beads.
+        TIER1("Unicow Pasture", new Boundary(2276, 4764, 2288, 4776), new Position(2282, 4770), 0, 0, -1, 5, Npcs.UNICOW, 8,
+                new BossMob[]{
+                        new BossMob(Npcs.UNICOW, 25, 10, 5, 8, List.of()),
+                        new BossMob(Npcs.IMP, 10, 5, 3, 6, List.of())
+                },
+                new TierCombatProfile(1.0,1.0,1.0,1.0,1.0,List.of()), 1.1, 1.0),
+        // drops/basilisk.yml, drops/lesser_demon.yml and drops/imp.yml introduce demonical threats with useful rune drops.
+        TIER2("Basilisk Lair", new Boundary(2274, 4762, 2290, 4778), new Position(2282, 4770), 25, 10_000, -1, 10, Npcs.BASILISK, 10,
+                new BossMob[]{
+                        new BossMob(Npcs.BASILISK, 40, 30, 30, 6, List.of()),
+                        new BossMob(Npcs.LESSER_DEMON, 50, 45, 35, 4, List.of()),
+                        new BossMob(Npcs.IMP, 15, 10, 5, 4, List.of())
+                },
+                new TierCombatProfile(1.1,1.05,1.05,1.05,1.0,List.of()), 1.1, 1.0),
+        // drops/hill_giant.yml and drops/ogre.yml note big bones and crude loot for developing players.
+        TIER3("Giants' Den", new Boundary(2272, 4760, 2292, 4780), new Position(2282, 4770), 75, 100_000, -1, 20, Npcs.HILL_GIANT, 12,
+                new BossMob[]{
+                        new BossMob(Npcs.HILL_GIANT, 35, 20, 20, 6, List.of()),
+                        new BossMob(Npcs.OGRE, 50, 30, 25, 4, List.of())
+                },
+                new TierCombatProfile(1.2,1.1,1.1,1.1,1.05,List.of()), 1.1, 1.0),
+        // drops/moss_giant.yml and drops/earth_warrior.yml provide nature rune supplies and warrior gear encouraging AoE magic.
+        TIER4("Moss Cave", new Boundary(2270, 4758, 2294, 4784), new Position(2282, 4770), 150, 250_000, -1, 25, Npcs.MOSS_GIANT, 15,
+                new BossMob[]{
+                        new BossMob(Npcs.MOSS_GIANT, 60, 40, 40, 6, List.of()),
+                        new BossMob(Npcs.EARTH_WARRIOR, 70, 50, 45, 4, List.of())
+                },
+                new TierCombatProfile(1.3,1.15,1.15,1.15,1.1,List.of()), 1.1, 1.0),
+        // drops/fire_giant.yml and drops/hellhound.yml reward rune gear and crystals fitting the mid-game.
+        TIER5("Fire Pit", new Boundary(2268, 4756, 2296, 4786), new Position(2282, 4770), 250, 500_000, -1, 30, Npcs.FIRE_GIANT, 18,
+                new BossMob[]{
+                        new BossMob(Npcs.FIRE_GIANT, 80, 60, 60, 5, List.of()),
+                        new BossMob(Npcs.HELLHOUND, 90, 70, 65, 3, List.of())
+                },
+                new TierCombatProfile(1.4,1.2,1.2,1.2,1.15,List.of()), 1.0, 1.0),
+        // drops/green_dragon.yml, drops/baby_green_dragon.yml and drops/bronze_dragon.yml contain hides and metals for crafting progression.
+        TIER6("Green Dragons", new Boundary(2266, 4754, 2298, 4788), new Position(2282, 4770), 350, 750_000, -1, 35, Npcs.GREEN_DRAGON, 22,
+                new BossMob[]{
+                        new BossMob(Npcs.GREEN_DRAGON, 120, 90, 90, 5, List.of()),
+                        new BossMob(Npcs.BABY_GREEN_DRAGON, 100, 80, 80, 4, List.of()),
+                        new BossMob(Npcs.BRONZE_DRAGON, 160, 120, 120, 2, List.of())
+                },
+                new TierCombatProfile(1.5,1.25,1.25,1.25,1.2,List.of()), 1.0, 1.0),
+        // drops/red_dragon.yml and drops/brutal_red_dragon.yml emphasise high hp foes that resist AoE.
+        TIER7("Red Dragons", new Boundary(2264, 4752, 2300, 4790), new Position(2282, 4770), 500, 1_000_000, -1, 40, Npcs.RED_DRAGON, 26,
+                new BossMob[]{
+                        new BossMob(Npcs.RED_DRAGON, 150, 110, 110, 4, List.of()),
+                        new BossMob(Npcs.BABY_RED_DRAGON, 130, 100, 100, 3, List.of()),
+                        new BossMob(Npcs.BRUTAL_RED_DRAGON, 220, 160, 160, 1, List.of())
+                },
+                new TierCombatProfile(1.6,1.3,1.3,1.3,1.25,List.of()), 0.9, 1.2),
+        // drops/black_dragon.yml and drops/brutal_black_dragon.yml feature valuable hides but punishing stats.
+        TIER8("Black Dragons", new Boundary(2262, 4750, 2302, 4792), new Position(2282, 4770), 650, 2_000_000, -1, 45, Npcs.BLACK_DRAGON, 30,
+                new BossMob[]{
+                        new BossMob(Npcs.BLACK_DRAGON, 180, 130, 130, 4, List.of()),
+                        new BossMob(Npcs.BRUTAL_BLACK_DRAGON, 260, 180, 180, 2, List.of())
+                },
+                new TierCombatProfile(1.7,1.35,1.35,1.35,1.3,List.of()), 0.9, 1.2),
+        // drops/black_demon.yml, drops/abyssal_demon.yml and drops/greater_demon.yml include rare rune drops befitting late tiers.
+        TIER9("Demon Domain", new Boundary(2260, 4748, 2304, 4794), new Position(2282, 4770), 800, 3_000_000, -1, 50, Npcs.BLACK_DEMON, 35,
+                new BossMob[]{
+                        new BossMob(Npcs.BLACK_DEMON, 200, 150, 150, 3, List.of("infernal_slam")),
+                        new BossMob(Npcs.ABYSSAL_DEMON, 220, 160, 160, 2, List.of()),
+                        new BossMob(Npcs.GREATER_DEMON, 170, 140, 140, 3, List.of())
+                },
+                new TierCombatProfile(1.8,1.4,1.4,1.4,1.35,List.of("infernal_slam")), 0.9, 1.2),
+        // drops/king_black_dragon.yml and drops/steel_dragon.yml grant elite loot for coordinated play.
+        TIER10("Dragon King", new Boundary(2258, 4746, 2306, 4796), new Position(2282, 4770), 1_000, 5_000_000, 11286, 60, Npcs.KING_BLACK_DRAGON, 40,
+                new BossMob[]{
+                        new BossMob(Npcs.KING_BLACK_DRAGON, 250, 180, 180, 1, List.of("infernal_slam")),
+                        new BossMob(Npcs.BRUTAL_BLACK_DRAGON, 260, 180, 180, 2, List.of("infernal_slam")),
+                        new BossMob(Npcs.STEEL_DRAGON, 200, 170, 170, 2, List.of())
+                },
+                new TierCombatProfile(2.0,1.5,1.5,1.45,1.4,List.of("infernal_slam")), 0.9, 1.2);
 
         static {
             TIER1.requiredKillCountToUnlockNext = 25;  TIER1.nextTier = TIER2;
@@ -194,19 +273,22 @@ public class BossInstanceManager {
         private final int desiredNpcDensity;
         private final BossMob[] mobs;
         private final TierCombatProfile combatProfile;
+        private final double aoeDamageMultiplier;
+        private final double aoeCooldownMultiplier;
         private final boolean dynamicWaveScaling;
         private int requiredKillCountToUnlockNext;
         private BossTier nextTier;
 
         BossTier(String zoneName, Boundary zoneBoundary, Position spawnTile, int killRequirement, int gpCost, int itemRequirement,
-                 int respawnTime, int bossNpcId, int desiredNpcDensity, BossMob[] mobs, TierCombatProfile combatProfile) {
+                 int respawnTime, int bossNpcId, int desiredNpcDensity, BossMob[] mobs, TierCombatProfile combatProfile,
+                 double aoeDamageMultiplier, double aoeCooldownMultiplier) {
             this(zoneName, zoneBoundary, spawnTile, killRequirement, gpCost, itemRequirement, respawnTime, bossNpcId,
-                    desiredNpcDensity, mobs, combatProfile, false);
+                    desiredNpcDensity, mobs, combatProfile, aoeDamageMultiplier, aoeCooldownMultiplier, false);
         }
 
         BossTier(String zoneName, Boundary zoneBoundary, Position spawnTile, int killRequirement, int gpCost, int itemRequirement,
                  int respawnTime, int bossNpcId, int desiredNpcDensity, BossMob[] mobs, TierCombatProfile combatProfile,
-                 boolean dynamicWaveScaling) {
+                 double aoeDamageMultiplier, double aoeCooldownMultiplier, boolean dynamicWaveScaling) {
             this.zoneName = zoneName;
             this.zoneBoundary = zoneBoundary;
             this.spawnTile = spawnTile;
@@ -218,6 +300,8 @@ public class BossInstanceManager {
             this.desiredNpcDensity = desiredNpcDensity;
             this.mobs = mobs;
             this.combatProfile = combatProfile;
+            this.aoeDamageMultiplier = aoeDamageMultiplier;
+            this.aoeCooldownMultiplier = aoeCooldownMultiplier;
             this.dynamicWaveScaling = dynamicWaveScaling;
         }
 
@@ -262,6 +346,13 @@ public class BossInstanceManager {
         }
 
         public TierCombatProfile getCombatProfile() { return combatProfile; }
+
+        /** Multiplier applied to damage dealt by hazards and NPCs in this tier. */
+        public double getDamageMultiplier() { return 1.0 + (ordinal() * 0.1); }
+
+        public double getAoeDamageMultiplier() { return aoeDamageMultiplier; }
+
+        public double getAoeCooldownMultiplier() { return aoeCooldownMultiplier; }
 
         public boolean isDynamicWaveScaling() { return dynamicWaveScaling; }
 
@@ -356,6 +447,11 @@ public class BossInstanceManager {
         int desiredTotal = Math.max(1, areaTiles / Math.max(1, tier.getDesiredNpcDensity()));
         int baseTotal = Arrays.stream(mobs).mapToInt(BossMob::getCount).sum();
         double ratio = baseTotal > 0 ? Math.max(1.0, (double) desiredTotal / baseTotal) : 1.0;
+        if (tier.ordinal() <= BossTier.TIER4.ordinal()) {
+            ratio *= 1.2;
+        } else if (tier.ordinal() >= BossTier.TIER7.ordinal()) {
+            ratio *= 0.8;
+        }
 
         Position spawnTile = tier.getSpawnTile();
         for (BossMob mob : mobs) {
@@ -441,6 +537,7 @@ public class BossInstanceManager {
         BossInstanceOverlayManager.clear(player);
         BossInstanceArea area = INSTANCES.remove(player);
         if (area != null) {
+            area.resetStreak(player);
             area.dispose();
         }
         InstancePerformanceTracker.InstanceResult result = player.getInstancePerformanceTracker().finish();
@@ -455,6 +552,11 @@ public class BossInstanceManager {
             PerformanceRank rank = PerformanceRank.forScore(result.score);
             if (rank.ordinal() >= PerformanceRank.GOLD.ordinal()) {
                 player.sendMessage("@gre@Achievement unlocked: " + rank.name() + " performer!");
+            }
+            int kills = player.getTierKillCounts().getOrDefault(result.tier, 0);
+            if (kills >= result.tier.getRequiredKillCountToUnlockNext()) {
+                String msg = player.getDisplayName() + " has completed " + getTierDisplayNameSafe(result.tier) + "!";
+                PlayerHandler.nonNullStream().forEach(p -> p.sendMessage(msg));
             }
         }
         player.setPreviewingBossInstance(false);

--- a/src/io/xeros/content/instances/InstanceMutatorManager.java
+++ b/src/io/xeros/content/instances/InstanceMutatorManager.java
@@ -12,6 +12,7 @@ import io.xeros.content.instances.hazard.HazardEffectModifier;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
+import io.xeros.content.instances.BossInstanceManager;
 import io.xeros.model.entity.player.PlayerHandler;
 import java.util.stream.Collectors;
 
@@ -68,7 +69,9 @@ public class InstanceMutatorManager {
             public void execute(CycleEventContainer container) {
                 globalDanger = Math.max(0, globalDanger - 1);
                 if (globalDanger > 80) {
-                    PlayerHandler.executeGlobalMessage("@red@The world trembles from hazardous energy!");
+                    PlayerHandler.nonNullStream()
+                            .filter(p -> BossInstanceManager.get(p) != null)
+                            .forEach(p -> p.sendMessage("@red@The world trembles from hazardous energy!"));
                 }
             }
         }, 100);

--- a/src/io/xeros/content/instances/TierRewardManager.java
+++ b/src/io/xeros/content/instances/TierRewardManager.java
@@ -13,8 +13,40 @@ public class TierRewardManager {
      * include items, tier points, or other benefits.
      */
     public static void reward(Player player, BossInstanceManager.BossTier tier) {
-        // Placeholder reward: 100k coins
-        player.getItems().addItem(995, 100_000);
-       player.sendMessage("You receive 100,000 coins for completing " + BossInstanceManager.getTierDisplayNameSafe(tier) + ".");
+        // Placeholder reward: 50k coins
+        player.getItems().addItem(995, 50_000);
+       player.sendMessage("You receive 50,000 coins for completing " + BossInstanceManager.getTierDisplayNameSafe(tier) + ".");
+    }
+
+    /** Grants a tier-scaled bonus when a player hits a killstreak milestone. */
+    public static void rewardKillstreak(Player player, BossInstanceManager.BossTier tier, int streak) {
+        int coins = calculateKillstreakReward(tier, streak);
+        player.getItems().addItem(995, coins);
+        player.sendMessage("@blu@Killstreak " + streak + "! You receive " + coins + " coins.");
+    }
+
+    /** Grants a bonus for AoE killstreak milestones. */
+    public static void rewardAoeKillstreak(Player player, BossInstanceManager.BossTier tier, int streak) {
+        int coins = calculateAoeKillstreakReward(tier, streak);
+        player.getItems().addItem(995, coins);
+        player.sendMessage("@red@AoE streak " + streak + "! Bonus " + coins + " coins.");
+    }
+
+    /** Small reward from direct hazard hits scaled by tier. */
+    public static void rewardHazardDrop(Player player, BossInstanceManager.BossTier tier) {
+        int coins = 250 * (tier.ordinal() + 1);
+        player.getItems().addItem(995, coins);
+    }
+
+    /** Calculates the coin reward for a killstreak without modifying player state. */
+    public static int calculateKillstreakReward(BossInstanceManager.BossTier tier, int streak) {
+        int level = streak / 10;
+        return 12_500 * level * (tier.ordinal() + 1);
+    }
+
+    /** Calculates the coin reward for an AoE killstreak milestone. */
+    public static int calculateAoeKillstreakReward(BossInstanceManager.BossTier tier, int streak) {
+        int level = streak / 5;
+        return 5_000 * level * (tier.ordinal() + 1);
     }
 }

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardDefinition.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardDefinition.java
@@ -9,7 +9,9 @@ import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Boundary;
 import io.xeros.model.entity.player.Player;
 import io.xeros.model.entity.player.Position;
+import io.xeros.model.StillGraphic;
 import io.xeros.util.Misc;
+import io.xeros.Server;
 
 public class EnvironmentalHazardDefinition {
 
@@ -40,11 +42,13 @@ public class EnvironmentalHazardDefinition {
         int x = forced != null ? forced.getX() : Misc.random(b.getMinimumX(), b.getMaximumX());
         int y = forced != null ? forced.getY() : Misc.random(b.getMinimumY(), b.getMaximumY());
         Position pos = new Position(x, y, area.getHeight());
-        int scaledDamage = (int) (finalTier.scale(damage) * dmgMod);
-        int scaledDrain = (int) (finalTier.scale(drain) * dmgMod);
-        int scaledStun = (int) (finalTier.scale(stun) * dmgMod);
+        double tierMod = area.getTier().getDamageMultiplier();
+        int scaledDamage = (int) (finalTier.scale(damage) * dmgMod * tierMod);
+        int scaledDrain = (int) (finalTier.scale(drain) * dmgMod * tierMod);
+        int scaledStun = (int) (finalTier.scale(stun) * dmgMod * tierMod);
         HazardContext ctx = new HazardContext(type, finalTier, pos);
         HazardDebugLogger.log(area, "Hazard " + type + " at " + pos);
+        Server.playerHandler.sendStillGfx(new StillGraphic(type.getGfxId(), pos), area);
         if (synergyMsg != null) {
             for (Player p : area.getPlayers()) {
                 p.sendMessage(synergyMsg);

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardPattern.java
@@ -5,6 +5,7 @@ import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Boundary;
 
 /**
  * Simple arena wide hazard patterns. The behaviour here is intentionally
@@ -55,9 +56,13 @@ public class EnvironmentalHazardPattern {
                 }
                 break;
             case CHAOS_RIFT:
+                Boundary b = area.getTier().getZoneBoundary();
                 for (Player p : area.getPlayers()) {
-                    p.getPA().movePlayer(p.getPosition().getX() + io.xeros.util.Misc.random(-1,1),
-                            p.getPosition().getY() + io.xeros.util.Misc.random(-1,1), p.getHeight());
+                    int nx = p.getPosition().getX() + io.xeros.util.Misc.random(-1,1);
+                    int ny = p.getPosition().getY() + io.xeros.util.Misc.random(-1,1);
+                    nx = Math.max(b.getMinimumX(), Math.min(b.getMaximumX(), nx));
+                    ny = Math.max(b.getMinimumY(), Math.min(b.getMaximumY(), ny));
+                    p.getPA().movePlayer(nx, ny, area.getHeight());
                     p.sendMessage("@pur@Chaotic forces warp your position!");
                 }
                 break;

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardPatternLoader.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardPatternLoader.java
@@ -31,7 +31,12 @@ public class EnvironmentalHazardPatternLoader {
             InputStreamReader reader = new InputStreamReader(EnvironmentalHazardPatternLoader.class.getResourceAsStream("/aoe_environmental_patterns.json"));
             Map<String, PatternConfig> map = new Gson().fromJson(reader, type);
             for (Map.Entry<String, PatternConfig> e : map.entrySet()) {
-                BossTier tier = BossTier.valueOf(e.getKey().toUpperCase());
+                // Pattern resources historically used keys like "TIER_1" whereas the enum
+                // constants are defined without the underscore ("TIER1").  To remain backwards
+                // compatible with existing JSON we normalise the key by stripping underscores
+                // before resolving the {@link BossTier}.
+                String normalised = e.getKey().replace("_", "").toUpperCase();
+                BossTier tier = BossTier.valueOf(normalised);
                 CONFIGS.put(tier, e.getValue());
             }
         } catch (Exception e) {

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardScheduler.java
@@ -7,10 +7,16 @@ import io.xeros.content.instances.hazard.HazardTier;
 import io.xeros.content.instances.hazard.HazardEffectModifier;
 import io.xeros.content.instances.hazard.WeeklyHazardManager;
 import io.xeros.content.instances.hazard.HazardDebugLogger;
+import io.xeros.content.instances.TierRewardManager;
+import io.xeros.content.combat.Hitmark;
+import io.xeros.model.StillGraphic;
+import io.xeros.Server;
 import io.xeros.model.cycleevent.CycleEvent;
 import io.xeros.model.cycleevent.CycleEventContainer;
 import io.xeros.model.cycleevent.CycleEventHandler;
 import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Boundary;
+import io.xeros.model.entity.player.Position;
 import io.xeros.util.Misc;
 
 import java.util.*;
@@ -71,7 +77,8 @@ public class EnvironmentalHazardScheduler {
                             }
                         }
                     }
-                    HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                    Position rand = randomPosition();
+                    HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg, rand);
                     recordLast(def, ctx);
                     InstanceMutatorManager.increaseDanger(5);
                     inProgress = false;
@@ -86,7 +93,8 @@ public class EnvironmentalHazardScheduler {
                                     .filter(h -> h.getType() == weekly.eliteHazard)
                                     .findFirst().orElse(null);
                             if (elite != null) {
-                                elite.activate(area, HazardTier.EXTREME, 1.0, "@red@Elite hazard empowered by global danger!");
+                                Position rand = randomPosition();
+                                elite.activate(area, HazardTier.EXTREME, 1.0, "@red@Elite hazard empowered by global danger!", rand);
                                 InstanceMutatorManager.increaseDanger(10);
                             }
                         }
@@ -105,6 +113,27 @@ public class EnvironmentalHazardScheduler {
                 }
             }, pfreq);
         }
+
+        // Periodic unavoidable pulses that keep players attentive.
+        CycleEventHandler.getSingleton().addEvent(area, new CycleEvent() {
+            @Override
+            public void execute(CycleEventContainer container) {
+                for (Player p : area.getPlayers()) {
+                    Position pos = clampPosition(p.getPosition());
+                    Server.playerHandler.sendStillGfx(new StillGraphic(EnvironmentalHazardType.DIRECT_HIT.getGfxId(), pos), area);
+                    int dmg = (int) Math.max(1, 4 * area.getTier().getDamageMultiplier());
+                    CycleEventHandler.getSingleton().addEvent(p, new CycleEvent() {
+                        @Override
+                        public void execute(CycleEventContainer c) {
+                            p.appendDamage(dmg, Hitmark.HIT);
+                            p.sendMessage("@red@A direct hit strikes you!");
+                            TierRewardManager.rewardHazardDrop(p, area.getTier());
+                            c.stop();
+                        }
+                    }, 2);
+                }
+            }
+        }, 50);
     }
 
     public void stop() {
@@ -141,7 +170,8 @@ public class EnvironmentalHazardScheduler {
                         }
                     }
                 }
-                HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg);
+                Position rand = randomPosition();
+                HazardContext ctx = def.activate(area, hazardTier, dmgMod, synergyMsg, rand);
                 recordLast(def, ctx);
                 cooldowns.put(trigger, now);
                 InstanceMutatorManager.increaseDanger(7);
@@ -185,7 +215,8 @@ public class EnvironmentalHazardScheduler {
     public boolean replay(EnvironmentalHazardType type) {
         HazardRecord r = lastHazards.get(type);
         if (r == null) return false;
-        r.def.activate(area, r.ctx.getTier(), 1.0, null, r.ctx.getPosition());
+        Position pos = clampPosition(r.ctx.getPosition());
+        r.def.activate(area, r.ctx.getTier(), 1.0, null, pos);
         HazardDebugLogger.log(area, "replay:" + type);
         return true;
     }
@@ -196,5 +227,19 @@ public class EnvironmentalHazardScheduler {
         HazardRecord(EnvironmentalHazardDefinition def, HazardContext ctx) {
             this.def = def; this.ctx = ctx;
         }
+    }
+
+    private Position randomPosition() {
+        Boundary b = area.getTier().getZoneBoundary();
+        int x = Misc.random(b.getMinimumX(), b.getMaximumX());
+        int y = Misc.random(b.getMinimumY(), b.getMaximumY());
+        return clampPosition(new Position(x, y, area.getHeight()));
+    }
+
+    private Position clampPosition(Position pos) {
+        Boundary b = area.getTier().getZoneBoundary();
+        int x = Math.max(b.getMinimumX(), Math.min(b.getMaximumX(), pos.getX()));
+        int y = Math.max(b.getMinimumY(), Math.min(b.getMaximumY(), pos.getY()));
+        return new Position(x, y, area.getHeight());
     }
 }

--- a/src/io/xeros/content/instances/hazard/EnvironmentalHazardType.java
+++ b/src/io/xeros/content/instances/hazard/EnvironmentalHazardType.java
@@ -1,7 +1,18 @@
 package io.xeros.content.instances.hazard;
 
 public enum EnvironmentalHazardType {
-    FIRE_TILE,
-    POISON_MIST,
-    CRUMBLING_FLOOR
+    FIRE_TILE(502),
+    POISON_MIST(110),
+    CRUMBLING_FLOOR(60),
+    DIRECT_HIT(157);
+
+    private final int gfxId;
+
+    EnvironmentalHazardType(int gfxId) {
+        this.gfxId = gfxId;
+    }
+
+    public int getGfxId() {
+        return gfxId;
+    }
 }

--- a/src/io/xeros/content/items/aoeweapons/AoeManager.java
+++ b/src/io/xeros/content/items/aoeweapons/AoeManager.java
@@ -43,6 +43,12 @@ public class AoeManager {
         int dmg = Misc.random(aoeData.DMG);
         int range = aoeData.Size;
         int delay = aoeData.Delay;
+        BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(player);
+        if (area != null && area.isWithinAoeZone(player.getPosition())) {
+            BossInstanceManager.BossTier tier = area.getTier();
+            dmg = (int) Math.round(dmg * tier.getAoeDamageMultiplier());
+            delay = (int) Math.max(1, Math.round(delay * tier.getAoeCooldownMultiplier()));
+        }
         int anim = aoeData.anim;
         int gfx = aoeData.gfx;
         String style = aoeData.style;
@@ -50,7 +56,6 @@ public class AoeManager {
         player.startAnimation(anim);
 
         if (player.isPlayer() && victim.isNPC()) {
-            BossInstanceManager.BossInstanceArea area = BossInstanceManager.get(player);
             victim.startGraphic(new Graphic(gfx, 0, Graphic.GraphicHeight.MIDDLE));
             for (NPC next : NPCHandler.npcs) {
                 if (next == null) {

--- a/src/io/xeros/model/entity/npc/NPC.java
+++ b/src/io/xeros/model/entity/npc/NPC.java
@@ -524,6 +524,9 @@ public class NPC extends Entity implements IHazardReactive {
     }
 
     public int modifyDamage(Player player, int damage) {
+        if (player.getInstance() instanceof io.xeros.content.instances.BossInstanceManager.BossInstanceArea area) {
+            damage = (int) Math.max(1, damage * area.getTier().getDamageMultiplier());
+        }
         return damage;
     }
 

--- a/src/test/java/io/xeros/content/instances/BossTierDamageTest.java
+++ b/src/test/java/io/xeros/content/instances/BossTierDamageTest.java
@@ -1,0 +1,51 @@
+package io.xeros.content.instances;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.xeros.content.instances.TierRewardManager;
+
+public class BossTierDamageTest {
+
+    @Test
+    public void damageScalingIncreasesWithTier() {
+        assertTrue(BossInstanceManager.BossTier.TIER1.getDamageMultiplier() <
+                BossInstanceManager.BossTier.TIER2.getDamageMultiplier());
+        assertTrue(BossInstanceManager.BossTier.TIER5.getDamageMultiplier() <
+                BossInstanceManager.BossTier.TIER10.getDamageMultiplier());
+    }
+
+    @Test
+    public void aoeModifiersDifferByTier() {
+        assertTrue(BossInstanceManager.BossTier.TIER1.getAoeDamageMultiplier() >
+                BossInstanceManager.BossTier.TIER7.getAoeDamageMultiplier());
+        assertTrue(BossInstanceManager.BossTier.TIER7.getAoeCooldownMultiplier() > 1.0);
+    }
+
+    @Test
+    public void npcDensityDecreasesWithTier() {
+        assertTrue(BossInstanceManager.BossTier.TIER1.getDesiredNpcDensity() <
+                BossInstanceManager.BossTier.TIER7.getDesiredNpcDensity());
+        assertTrue(BossInstanceManager.BossTier.TIER7.getDesiredNpcDensity() <
+                BossInstanceManager.BossTier.TIER10.getDesiredNpcDensity());
+    }
+
+    @Test
+    public void tierRostersContainVariety() {
+        assertTrue(BossInstanceManager.BossTier.TIER2.getMobs().length > 1);
+        assertTrue(BossInstanceManager.BossTier.TIER8.getMobs().length > 1);
+    }
+
+    @Test
+    public void killstreakRewardsScale() {
+        int t1 = TierRewardManager.calculateKillstreakReward(BossInstanceManager.BossTier.TIER1, 10);
+        int t10 = TierRewardManager.calculateKillstreakReward(BossInstanceManager.BossTier.TIER10, 10);
+        assertTrue(t10 > t1);
+    }
+
+    @Test
+    public void killstreakRewardValuesHalved() {
+        assertEquals(12_500, TierRewardManager.calculateKillstreakReward(BossInstanceManager.BossTier.TIER1, 10));
+        assertEquals(5_000, TierRewardManager.calculateAoeKillstreakReward(BossInstanceManager.BossTier.TIER1, 5));
+    }
+}


### PR DESCRIPTION
## Summary
- Correct pagination so tier 5 appears in boss instance dialogue options
- Limit hazardous energy tremor broadcast to players inside an AoE instance
- Normalize hazard pattern tier keys to avoid enum lookup errors
- Reduce AoE minigame coin rewards across completion bonuses, killstreak milestones, AoE streaks and hazard drops

## Testing
- `gradle test` *(fails: package org.junit.jupiter.api does not exist; NoSuchFieldError: JCImport qualid)*

------
https://chatgpt.com/codex/tasks/task_e_6896b12cc3d88320be53ac720ea302e8