### PR TITLE
Add data-driven AOE boss tier framework

### DIFF
--- a/data/aoe/aoe_boss_tiers.json
+++ b/data/aoe/aoe_boss_tiers.json
@@ -1,0 +1,120 @@
+[
+  {
+    "tier": 1,
+    "zoneName": "Unicow Pasture",
+    "unlockKills": 10,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Unicow", "npcId": 3601},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 2,
+    "zoneName": "Bandos Stronghold",
+    "unlockKills": 25,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "General Graardor", "npcId": 2215},
+    "minions": [
+      {"name": "Sergeant Strongstack", "npcId": 2216, "count": 1},
+      {"name": "Sergeant Steelwill", "npcId": 2217, "count": 1},
+      {"name": "Sergeant Grimspike", "npcId": 2218, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 3,
+    "zoneName": "Zamorak Fortress",
+    "unlockKills": 35,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "K'ril Tsutsaroth", "npcId": 3129},
+    "minions": [
+      {"name": "Tstanon Karlak", "npcId": 3130, "count": 1},
+      {"name": "Zakl'n Gritch", "npcId": 3131, "count": 1},
+      {"name": "Balfrug Kreeyath", "npcId": 3132, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 4,
+    "zoneName": "Saradomin Encampment",
+    "unlockKills": 45,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Commander Zilyana", "npcId": 2205},
+    "minions": [
+      {"name": "Bree", "npcId": 2208, "count": 1},
+      {"name": "Starlight", "npcId": 2206, "count": 1},
+      {"name": "Growler", "npcId": 2207, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 5,
+    "zoneName": "Armadyl Eyrie",
+    "unlockKills": 55,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Kree'arra", "npcId": 3162},
+    "minions": [
+      {"name": "Flight Kilisa", "npcId": 3165, "count": 1},
+      {"name": "Flockleader Geerin", "npcId": 3164, "count": 1},
+      {"name": "Wingman Skree", "npcId": 3163, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 6,
+    "zoneName": "Dagannoth Lair",
+    "unlockKills": 65,
+    "aoeGrid": {"rows": 1, "cols": 3, "spacing": 4},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Dagannoth Prime", "npcId": 2266},
+    "minions": [
+      {"name": "Dagannoth Rex", "npcId": 2267, "count": 1},
+      {"name": "Dagannoth Supreme", "npcId": 2265, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 7,
+    "zoneName": "Kalphite Hive",
+    "unlockKills": 75,
+    "aoeGrid": {"rows": 1, "cols": 1, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Kalphite Queen", "npcId": 963},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 8,
+    "zoneName": "King Black Dragon Lair",
+    "unlockKills": 85,
+    "aoeGrid": {"rows": 1, "cols": 1, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "King Black Dragon", "npcId": 239},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 9,
+    "zoneName": "Chaos Elemental Plane",
+    "unlockKills": 95,
+    "aoeGrid": {"rows": 1, "cols": 1, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Chaos Elemental", "npcId": 2054},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  }
+]

--- a/src/io/xeros/content/commands/all/Aoe.java
+++ b/src/io/xeros/content/commands/all/Aoe.java
@@ -1,0 +1,92 @@
+package io.xeros.content.commands.all;
+
+import io.xeros.content.commands.Command;
+import io.xeros.content.instances.aoe.AoeBossTierLoader;
+import io.xeros.content.instances.aoe.AoeTierController;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+
+import java.util.Optional;
+
+/**
+ * Entry point command for interacting with the AOE boss tier system. The
+ * command syntax matches "::aoe tier <subcommand>".
+ */
+public class Aoe extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        String[] parts = input.split(" ");
+        if (parts.length < 2 || !parts[0].equalsIgnoreCase("tier")) {
+            player.sendMessage("Usage: ::aoe tier <open|status|start|set|simulate|reload>");
+            return;
+        }
+        String sub = parts[1].toLowerCase();
+        switch (sub) {
+            case "open":
+                player.sendMessage("AOE tier selection UI not implemented in this build.");
+                break;
+            case "status":
+                int tier = AoeTierController.getUnlockedTier(player);
+                player.sendMessage("AOE tier: " + tier);
+                break;
+            case "start":
+                if (parts.length >= 3) {
+                    int t = Integer.parseInt(parts[2]);
+                    AoeTierController.startTier(player, t);
+                } else {
+                    player.sendMessage("Usage: ::aoe tier start <tier>");
+                }
+                break;
+            case "set":
+                if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                    player.sendMessage("Admin only command.");
+                    return;
+                }
+                if (parts.length >= 3) {
+                    int t = Integer.parseInt(parts[2]);
+                    AoeTierController.setUnlockedTier(player, t);
+                    player.sendMessage("Set unlocked AOE tier to " + t);
+                } else {
+                    player.sendMessage("Usage: ::aoe tier set <tier>");
+                }
+                break;
+            case "simulate":
+                if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                    player.sendMessage("Admin only command.");
+                    return;
+                }
+                if (parts.length >= 4) {
+                    int t = Integer.parseInt(parts[2]);
+                    int kills = Integer.parseInt(parts[3]);
+                    for (int i = 0; i < kills; i++) {
+                        AoeTierController.incrementKill(player, t);
+                    }
+                    player.sendMessage("Simulated " + kills + " kills for tier " + t);
+                } else {
+                    player.sendMessage("Usage: ::aoe tier simulate <tier> <kills>");
+                }
+                break;
+            case "reload":
+                if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                    player.sendMessage("Admin only command.");
+                    return;
+                }
+                AoeBossTierLoader.reload();
+                player.sendMessage("AOE tier definitions reloaded.");
+                break;
+            default:
+                player.sendMessage("Unknown subcommand: " + sub);
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("AOE tier utilities");
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeBossSpawner.java
+++ b/src/io/xeros/content/instances/aoe/AoeBossSpawner.java
@@ -1,0 +1,50 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.npc.NPCSpawning;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility used by {@link AoeTierController} for spawning a boss and its minions
+ * into an instance. This implementation focuses on simplicity and assumes the
+ * caller manages lifecycle and timers.
+ */
+public class AoeBossSpawner {
+
+    /**
+     * Spawns the boss and minions defined by {@code def} centred on
+     * {@code centre}. Returns the spawned NPCs for tracking.
+     */
+    public static List<NPC> spawn(Player owner, AoeBossTierDef def, Position centre) {
+        List<NPC> spawned = new ArrayList<>();
+        if (def == null || centre == null) {
+            return spawned;
+        }
+        // Spawn boss in centre
+        NPC boss = NPCSpawning.spawnNpc(owner, def.boss.npcId, centre.getX(), centre.getY(), centre.getHeight(), 1, 0, false, false, null);
+        if (boss != null) {
+            spawned.add(boss);
+        }
+        // Offsets for up to three minions around the boss
+        int[][] offsets = new int[][]{{1,0}, {-1,0}, {0,1}, {0,-1}};
+        int spacing = def.getAoeGrid() != null ? def.getAoeGrid().spacing : 1;
+        if (def.minions != null) {
+            for (int i = 0; i < def.minions.size() && i < offsets.length; i++) {
+                AoeBossTierDef.Npc m = def.minions.get(i);
+                int x = centre.getX() + offsets[i][0] * spacing;
+                int y = centre.getY() + offsets[i][1] * spacing;
+                for (int count = 0; count < Math.max(1, m.count); count++) {
+                    NPC npc = NPCSpawning.spawnNpc(owner, m.npcId, x, y, centre.getHeight(), 1, 0, false, false, null);
+                    if (npc != null) {
+                        spawned.add(npc);
+                    }
+                }
+            }
+        }
+        return spawned;
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeBossTierDef.java
+++ b/src/io/xeros/content/instances/aoe/AoeBossTierDef.java
@@ -1,0 +1,75 @@
+package io.xeros.content.instances.aoe;
+
+import java.util.List;
+
+/**
+ * Data driven definition for an AOE boss tier. Instances of this class are
+ * loaded from {@code data/aoe/aoe_boss_tiers.json} via {@link AoeBossTierLoader}.
+ */
+public class AoeBossTierDef {
+
+    public static class Grid {
+        public int rows;
+        public int cols;
+        public int spacing;
+    }
+
+    public static class Npc {
+        public String name;
+        public int npcId;
+        public int count = 1;
+    }
+
+    public static class Rewards {
+        public double xpMultOnTask = 1.0;
+        public double xpMultOffTask = 1.0;
+        public double dropMult = 1.0;
+        public int fortuneXp = 0;
+    }
+
+    public int tier;
+    public String zoneName;
+    public int unlockKills;
+    public Grid aoeGrid;
+    public int aggroRange;
+    public int respawnSeconds;
+    public Npc boss;
+    public List<Npc> minions;
+    public Rewards rewards;
+
+    public int getTier() {
+        return tier;
+    }
+
+    public String getZoneName() {
+        return zoneName;
+    }
+
+    public int getUnlockKills() {
+        return unlockKills;
+    }
+
+    public Grid getAoeGrid() {
+        return aoeGrid;
+    }
+
+    public int getAggroRange() {
+        return aggroRange;
+    }
+
+    public int getRespawnSeconds() {
+        return respawnSeconds;
+    }
+
+    public Npc getBoss() {
+        return boss;
+    }
+
+    public List<Npc> getMinions() {
+        return minions;
+    }
+
+    public Rewards getRewards() {
+        return rewards;
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeBossTierLoader.java
+++ b/src/io/xeros/content/instances/aoe/AoeBossTierLoader.java
@@ -1,0 +1,60 @@
+package io.xeros.content.instances.aoe;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Loads {@link AoeBossTierDef} definitions from disk. The file is
+ * expected at {@code data/aoe/aoe_boss_tiers.json} relative to the
+ * working directory.
+ */
+public class AoeBossTierLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(AoeBossTierLoader.class);
+    private static final Path FILE = Paths.get("data/aoe/aoe_boss_tiers.json");
+    private static final Gson GSON = new Gson();
+
+    private static List<AoeBossTierDef> tiers = Collections.emptyList();
+
+    public static void load() {
+        try {
+            if (!Files.exists(FILE)) {
+                logger.warn("AOE boss tier file not found: {}", FILE.toAbsolutePath());
+                tiers = Collections.emptyList();
+                return;
+            }
+            String json = Files.readString(FILE);
+            tiers = GSON.fromJson(json, new TypeToken<List<AoeBossTierDef>>(){}.getType());
+            logger.info("Loaded {} AOE boss tiers.", tiers.size());
+        } catch (IOException e) {
+            logger.error("Error loading AOE boss tiers", e);
+            tiers = Collections.emptyList();
+        }
+    }
+
+    public static void reload() {
+        load();
+    }
+
+    public static List<AoeBossTierDef> getTiers() {
+        return tiers;
+    }
+
+    public static AoeBossTierDef getTier(int tier) {
+        for (AoeBossTierDef def : tiers) {
+            if (def.tier == tier) {
+                return def;
+            }
+        }
+        return null;
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTierController.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierController.java
@@ -1,0 +1,55 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+
+import java.util.List;
+
+/**
+ * Minimal controller for starting tiers and tracking player progress. It stores
+ * unlock and killcount data on the {@link Player}'s attribute map to avoid
+ * invasive save changes.
+ */
+public class AoeTierController {
+
+    private static final String ATTR_UNLOCKED = "aoe_unlocked_tier";
+    private static String kcKey(int tier) { return "aoe_kc_" + tier; }
+
+    public static int getUnlockedTier(Player player) {
+        return player.getAttributes().getInt(ATTR_UNLOCKED, 1);
+    }
+
+    public static int getKillCount(Player player, int tier) {
+        return player.getAttributes().getInt(kcKey(tier), 0);
+    }
+
+    public static void setUnlockedTier(Player player, int tier) {
+        player.getAttributes().setInt(ATTR_UNLOCKED, tier);
+    }
+
+    public static void incrementKill(Player player, int tier) {
+        int kc = getKillCount(player, tier) + 1;
+        player.getAttributes().setInt(kcKey(tier), kc);
+        AoeBossTierDef def = AoeBossTierLoader.getTier(tier);
+        if (def != null && kc >= def.unlockKills && tier >= getUnlockedTier(player)) {
+            setUnlockedTier(player, tier + 1);
+            player.sendMessage("\uD83D\uDD13 You have unlocked AOE tier " + (tier + 1) + ".");
+        }
+    }
+
+    /** Starts the given tier at the player's current location. */
+    public static List<NPC> startTier(Player player, int tier) {
+        AoeBossTierDef def = AoeBossTierLoader.getTier(tier);
+        if (def == null) {
+            player.sendMessage("Unknown tier: " + tier);
+            return List.of();
+        }
+        if (tier > getUnlockedTier(player)) {
+            player.sendMessage("You have not unlocked this tier yet.");
+            return List.of();
+        }
+        Position centre = new Position(player.absX, player.absY, player.heightLevel);
+        return AoeBossSpawner.spawn(player, def, centre);
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTierEvents.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierEvents.java
@@ -1,0 +1,24 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.player.Player;
+
+/**
+ * Static hooks that tie the tier system into NPC death events. The actual game
+ * engine should call {@link #onNpcDeath(Player, NPC)} whenever an NPC dies so
+ * that kill counts can be tracked.
+ */
+public class AoeTierEvents {
+
+    public static void onNpcDeath(Player player, NPC npc) {
+        if (player == null || npc == null) {
+            return;
+        }
+        for (AoeBossTierDef def : AoeBossTierLoader.getTiers()) {
+            if (def.boss != null && def.boss.npcId == npc.npcId) {
+                AoeTierController.incrementKill(player, def.tier);
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define JSON-driven boss tier configuration for AOE instances
- load and spawn AOE boss tiers with basic controller and events
- expose `::aoe tier` command for managing tiers

## Testing
- `gradle test` *(fails: Execution failed for task ':compileJava'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b62385af0c8320a2093f76bc5000f4