### PR TITLE
Turmoil — fix AOE tier loader and dialogue wiring

### DIFF
--- a/data/aoe/aoe_boss_tiers.json
+++ b/data/aoe/aoe_boss_tiers.json
@@ -1,0 +1,120 @@
+[
+  {
+    "tier": 1,
+    "zoneName": "Unicow Pasture",
+    "unlockKills": 10,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Unicow", "npcId": 3601},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 2,
+    "zoneName": "Bandos Stronghold",
+    "unlockKills": 25,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "General Graardor", "npcId": 2215},
+    "minions": [
+      {"name": "Sergeant Strongstack", "npcId": 2216, "count": 1},
+      {"name": "Sergeant Steelwill", "npcId": 2217, "count": 1},
+      {"name": "Sergeant Grimspike", "npcId": 2218, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 3,
+    "zoneName": "Zamorak Fortress",
+    "unlockKills": 35,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "K'ril Tsutsaroth", "npcId": 3129},
+    "minions": [
+      {"name": "Tstanon Karlak", "npcId": 3130, "count": 1},
+      {"name": "Zakl'n Gritch", "npcId": 3131, "count": 1},
+      {"name": "Balfrug Kreeyath", "npcId": 3132, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 4,
+    "zoneName": "Saradomin Encampment",
+    "unlockKills": 45,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Commander Zilyana", "npcId": 2205},
+    "minions": [
+      {"name": "Bree", "npcId": 2208, "count": 1},
+      {"name": "Starlight", "npcId": 2206, "count": 1},
+      {"name": "Growler", "npcId": 2207, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 5,
+    "zoneName": "Armadyl Eyrie",
+    "unlockKills": 55,
+    "aoeGrid": {"rows": 2, "cols": 2, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Kree'arra", "npcId": 3162},
+    "minions": [
+      {"name": "Flight Kilisa", "npcId": 3165, "count": 1},
+      {"name": "Flockleader Geerin", "npcId": 3164, "count": 1},
+      {"name": "Wingman Skree", "npcId": 3163, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 6,
+    "zoneName": "Dagannoth Lair",
+    "unlockKills": 65,
+    "aoeGrid": {"rows": 1, "cols": 3, "spacing": 4},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Dagannoth Prime", "npcId": 2266},
+    "minions": [
+      {"name": "Dagannoth Rex", "npcId": 2267, "count": 1},
+      {"name": "Dagannoth Supreme", "npcId": 2265, "count": 1}
+    ],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 7,
+    "zoneName": "Kalphite Hive",
+    "unlockKills": 75,
+    "aoeGrid": {"rows": 1, "cols": 1, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Kalphite Queen", "npcId": 963},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 8,
+    "zoneName": "King Black Dragon Lair",
+    "unlockKills": 85,
+    "aoeGrid": {"rows": 1, "cols": 1, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "King Black Dragon", "npcId": 239},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  },
+  {
+    "tier": 9,
+    "zoneName": "Chaos Elemental Plane",
+    "unlockKills": 95,
+    "aoeGrid": {"rows": 1, "cols": 1, "spacing": 3},
+    "aggroRange": 10,
+    "respawnSeconds": 25,
+    "boss": {"name": "Chaos Elemental", "npcId": 2054},
+    "minions": [],
+    "rewards": {"xpMultOnTask": 1.0, "xpMultOffTask": 0.6, "dropMult": 1.0, "fortuneXp": 50}
+  }
+]

--- a/data/aoe/aoe_tier_rewards.json
+++ b/data/aoe/aoe_tier_rewards.json
@@ -1,0 +1,117 @@
+[
+  {
+    "tier": 1,
+    "name": "Unicow Pen",
+    "endOfRunRolls": 0,
+    "bonusRewards": [],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 0,
+    "reportTitle": "AOE Tier Rewards — T1 Unicow"
+  },
+  {
+    "tier": 2,
+    "name": "Bandos Stronghold",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 50000, "max": 150000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 50,
+    "reportTitle": "AOE Tier Rewards — T2 Bandos"
+  },
+  {
+    "tier": 3,
+    "name": "Zamorak Fortress",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 100000, "max": 200000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 60,
+    "reportTitle": "AOE Tier Rewards — T3 Zamorak"
+  },
+  {
+    "tier": 4,
+    "name": "Saradomin Encampment",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 150000, "max": 250000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 70,
+    "reportTitle": "AOE Tier Rewards — T4 Saradomin"
+  },
+  {
+    "tier": 5,
+    "name": "Armadyl Eyrie",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 200000, "max": 300000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 80,
+    "reportTitle": "AOE Tier Rewards — T5 Armadyl"
+  },
+  {
+    "tier": 6,
+    "name": "Dagannoth Lair",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 250000, "max": 350000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 90,
+    "reportTitle": "AOE Tier Rewards — T6 Dagannoth Kings"
+  },
+  {
+    "tier": 7,
+    "name": "Kalphite Hive",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 300000, "max": 400000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 100,
+    "reportTitle": "AOE Tier Rewards — T7 Kalphite Queen"
+  },
+  {
+    "tier": 8,
+    "name": "King Black Dragon Lair",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 350000, "max": 450000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 110,
+    "reportTitle": "AOE Tier Rewards — T8 King Black Dragon"
+  },
+  {
+    "tier": 9,
+    "name": "Chaos Elemental Plane",
+    "endOfRunRolls": 1,
+    "bonusRewards": [
+      {"itemId": 995, "min": 400000, "max": 500000}
+    ],
+    "bankAllDrops": true,
+    "blacklist": [],
+    "whitelist": [],
+    "fortuneXpPerKill": 120,
+    "reportTitle": "AOE Tier Rewards — T9 Chaos Elemental"
+  }
+]

--- a/src/io/xeros/ServerStartup.java
+++ b/src/io/xeros/ServerStartup.java
@@ -60,6 +60,7 @@ import io.xeros.util.discord.DiscordIntegration;
 import io.xeros.util.offlinestorage.ItemCollection;
 import io.xeros.model.world.objects.GlobalObject;
 import io.xeros.content.tools.ToolAugments;
+import io.xeros.content.instances.aoe.AoeBossTierLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +103,7 @@ public class ServerStartup {
         }
         ItemStats.load();
         NpcDef.load();
+        AoeBossTierLoader.loadAllOrWarn();
         // Npc Combat Definition must be above npc load
         NpcCombatDefinition.load();
         Server.npcHandler.init();

--- a/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
+++ b/src/io/xeros/content/dialogue/impl/BossInstanceDialogue.java
@@ -1,42 +1,29 @@
 package io.xeros.content.dialogue.impl;
 
-import io.xeros.Server;
 import io.xeros.content.dialogue.DialogueBuilder;
 import io.xeros.content.dialogue.DialogueOption;
-import io.xeros.content.instances.BossInstanceManager;
-import io.xeros.content.instances.BossInstanceManager.BossTier;
-import io.xeros.model.definitions.ItemDef;
-import io.xeros.model.entity.player.Player;
-import io.xeros.model.items.GameItem;
-import io.xeros.util.Misc;
+import io.xeros.content.instances.aoe.AoeBossTierDef;
+import io.xeros.content.instances.aoe.AoeBossTierLoader;
+import io.xeros.content.instances.aoe.AoeTierController;
+import io.xeros.content.instances.aoe.AoeTierRepo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.xeros.model.entity.player.Player;
+
+import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
- * Dialogue allowing players to select and enter boss instance tiers.
- *
- * <p>This implementation avoids blank options, colour codes locked/unlocked tiers
- * and supports pagination when more than five tiers exist.</p>
+ * Dialogue for selecting AOE boss tiers. Reads from {@link AoeTierRepo}
+ * each time it opens and paginates over the list.
  */
 public class BossInstanceDialogue extends DialogueBuilder {
 
-    /** NPC used for the dialogue head. */
-    private static final int NPC_ID = io.xeros.model.Npcs.INSTANCE_MASTER;
-
-    /** Maximum number of options shown per page. */
+    private static final Logger logger = LoggerFactory.getLogger(BossInstanceDialogue.class);
     private static final int OPTIONS_PER_PAGE = 5;
-
-    /** Maximum length of an option label before it is truncated. */
-    private static final int MAX_OPTION_LENGTH = 50;
-
-    /** Current page being viewed. */
     private final int page;
-
-    /** Tiers displayed on the current page mapped by slot. */
-    private final List<BossTier> displayed = new ArrayList<>(OPTIONS_PER_PAGE);
 
     public BossInstanceDialogue(Player player) {
         this(player, 0);
@@ -45,141 +32,75 @@ public class BossInstanceDialogue extends DialogueBuilder {
     private BossInstanceDialogue(Player player, int page) {
         super(player);
         this.page = page;
-        setNpcId(NPC_ID);
-        start();
+        build();
     }
 
-    /**
-     * Builds and sends the tier options for the current page. Any unused slots
-     * are filled with a red "Unavailable" placeholder to prevent blank lines.
-     */
-    public void start() {
+    private void build() {
+        List<AoeBossTierDef> tiers = AoeTierRepo.get();
         Player player = getPlayer();
-        BossTier[] tiers = BossTier.values();
-
-        // First page can show four tiers (one slot reserved for "More"),
-        // subsequent pages show three tiers because both navigation options
-        // may be present. Compute the starting index accordingly so tiers
-        // are not skipped.
-        int startIndex;
-        if (page == 0) {
-            startIndex = 0;
-        } else {
-            int firstPageCount = OPTIONS_PER_PAGE - 1; // 4 tiers on page 0
-            int subsequentPageCount = OPTIONS_PER_PAGE - 2; // 3 tiers when back+more are shown
-            startIndex = firstPageCount + (page - 1) * subsequentPageCount;
-        }
-
-        displayed.clear();
-
-        Misc.println("BossInstanceDialogue open page=" + page + " unlocked=" + player.getUnlockedBossTiers());
-
-        List<DialogueOption> opts = new ArrayList<>();
-
-        boolean addBack = page > 0;
-        boolean addMore = startIndex + OPTIONS_PER_PAGE < tiers.length;
-
-        int capacity = OPTIONS_PER_PAGE - (addBack ? 1 : 0) - (addMore ? 1 : 0);
-
-        for (int i = 0; i < capacity && startIndex + i < tiers.length; i++) {
-            BossTier tier = tiers[startIndex + i];
-            displayed.add(tier);
-            String label = buildTierLabel(player, tier);
-            final int slot = opts.size();
-            opts.add(new DialogueOption(label, p -> run(0, slot)));
-        }
-
-        if (addBack) {
-            displayed.add(null);
-            opts.add(new DialogueOption("Back", p -> p.start(new BossInstanceDialogue(p, page - 1))));
-        }
-        if (addMore) {
-            displayed.add(null);
-            opts.add(new DialogueOption("More", p -> p.start(new BossInstanceDialogue(p, page + 1))));
-        }
-
-        String[] labels = opts.stream().map(DialogueOption::getTitle).toArray(String[]::new);
-        player.getDH().sendOptionDialogue("Choose a Boss Tier", labels);
-        option("Choose a Boss Tier", opts.toArray(new DialogueOption[0]));
-    }
-
-    /**
-     * Builds a safe, colour-coded label for a tier showing progress and key drops.
-     * <p>
-     * The resulting string is logged and truncated if it exceeds {@link #MAX_OPTION_LENGTH}
-     * to prevent invisible dialogue options.
-     * </p>
-     */
-    private String buildTierLabel(Player player, BossTier tier) {
-        if (tier == null) {
-            Misc.println("BossInstanceDialogue warning: null tier label");
-            return "@red@Unavailable";
-        }
-
-        String zone = tier.getZoneName();
-        if (zone == null || zone.trim().isEmpty()) {
-            zone = "Unknown Zone";
-            Misc.println("BossInstanceDialogue warning: missing zone name for " + tier);
-        }
-
-        // Sanitize the zone to avoid invisible or client-breaking characters.
-        zone = zone.replaceAll("[^\\p{ASCII}]", "");
-        zone = zone.replaceAll("[–—•]", "-");
-        StringBuilder label = new StringBuilder(BossInstanceManager.getTierDisplayNameSafe(tier, player));
-
-        // Append up to three key drop names
-        List<GameItem> drops = Server.getDropManager().getNPCdrops(tier.getBossNpcId());
-        if (drops != null && !drops.isEmpty()) {
-            String dropNames = drops.stream()
-                    .limit(3)
-                    .map(drop -> {
-                        ItemDef def = ItemDef.forId(drop.getId());
-                        return def != null ? def.getName() : "?";
-                    })
-                    .collect(Collectors.joining(", "));
-            if (!dropNames.isEmpty()) {
-                label.append(" - ").append(dropNames);
-            }
-        }
-
-        String result = label.toString();
-
-        // Strip any remaining non-ASCII characters after building the label.
-        result = result.replaceAll("[^\\p{ASCII}]", "");
-        result = result.replaceAll("[–—•]", "-");
-        if (result.length() > MAX_OPTION_LENGTH) {
-            Misc.println("BossInstanceDialogue truncating label for " + tier + " from " + result.length() + " chars: " + result);
-            result = result.substring(0, MAX_OPTION_LENGTH - 3) + "...";
-        }
-
-        Misc.println("BossInstanceDialogue option tier=" + tier + " zone=" + zone + " display=" + result);
-        return result;
-    }
-
-    /**
-     * Handles option selection. Slots map to the tiers displayed on the current page.
-     */
-    public void run(int interfaceId, int slot) {
-        Player player = getPlayer();
-        if (slot < 0 || slot >= displayed.size()) {
+        if (tiers.isEmpty()) {
+            String path = AoeBossTierLoader.defaultFile().toFile().getAbsolutePath();
+            logger.info("[AOE-DLG] Open with empty tier list. Checked: {} exists={}", path, new File(path).exists());
+            player.start(new DialogueBuilder(player).statement(
+                    "No tiers configured (file: " + path + "). Use ::aoe tier reload."));
             return;
         }
-
-        BossTier tier = displayed.get(slot);
-        Misc.println("BossInstanceDialogue click slot=" + slot + " tier=" + (tier == null ? "null" : tier.name()));
-        if (tier == null) {
-            return; // placeholder option
+        int totalPages = (int) Math.ceil(tiers.size() / (double) OPTIONS_PER_PAGE);
+        logger.info("[AOE-DLG] Open: total={}, page={}/{}", tiers.size(), page + 1, totalPages);
+        int startIndex = page * OPTIONS_PER_PAGE;
+        List<DialogueOption> options = new ArrayList<>();
+        for (int i = 0; i < OPTIONS_PER_PAGE && startIndex + i < tiers.size(); i++) {
+            AoeBossTierDef def = tiers.get(startIndex + i);
+            final int tierNumber = def.tier;
+            String label = optionLabel(player, def);
+            options.add(new DialogueOption(label, p -> handleSelect(p, tierNumber, def)));
         }
+        if (page > 0) {
+            options.add(new DialogueOption("Back", p -> p.start(new BossInstanceDialogue(p, page - 1))));
+        }
+        if (startIndex + OPTIONS_PER_PAGE < tiers.size()) {
+            options.add(new DialogueOption("More", p -> p.start(new BossInstanceDialogue(p, page + 1))));
+        }
+        option("AOE Boss Tiers (Page " + (page + 1) + "/" + totalPages + ")",
+                options.toArray(new DialogueOption[0]));
+    }
 
-        if (player.getUnlockedBossTiers().contains(tier)) {
-            BossInstanceManager.enter(player, tier);
+    private void handleSelect(Player player, int tier, AoeBossTierDef def) {
+        String state = def.disabled ? "Disabled" : (tier <= AoeTierController.getUnlockedTier(player) ? "Unlocked" : "Locked");
+        logger.info("[AOE-DLG] Select tier={} state={}", tier, state);
+        if (def.disabled) {
+            player.sendMessage(def.getDisabledReason());
+            return;
+        }
+        if (tier <= AoeTierController.getUnlockedTier(player)) {
+            AoeTierController.startTier(player, tier);
             player.getPA().closeAllWindows();
         } else {
-            BossTier prev = Arrays.stream(BossTier.values()).filter(t -> t.getNextTier() == tier).findFirst().orElse(null);
-            int progress = prev != null ? player.getTierKillCounts().getOrDefault(prev, 0) : 0;
-            int required = prev != null ? prev.getRequiredKillCountToUnlockNext() : tier.getKillRequirement();
-            int remaining = Math.max(0, required - progress);
+            int prevTier = tier - 1;
+            int kc = AoeTierController.getKillCount(player, prevTier);
+            int req = def.unlockKills;
+            int remaining = Math.max(0, req - kc);
             player.sendMessage("You must kill " + remaining + " more to unlock this tier.");
         }
     }
+
+    private String optionLabel(Player player, AoeBossTierDef def) {
+        String zone = safe(def.zoneName);
+        if (def.disabled) {
+            return "T" + def.tier + " - " + zone + " [Disabled: " + def.getDisabledReason() + "]";
+        }
+        boolean unlocked = def.tier <= AoeTierController.getUnlockedTier(player);
+        if (unlocked) {
+            return "T" + def.tier + " - " + zone + " [Unlocked]";
+        }
+        return "T" + def.tier + " - " + zone + " [Locked " + def.unlockKills + "]";
+    }
+
+    private static String safe(String s) {
+        if (s == null || s.isBlank()) {
+            return "Unknown";
+        }
+        return s.replaceAll("[^\\p{ASCII}]", "");
+    }
 }
+

--- a/src/io/xeros/content/instances/aoe/AoeBossSpawner.java
+++ b/src/io/xeros/content/instances/aoe/AoeBossSpawner.java
@@ -1,0 +1,50 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.npc.NPCSpawning;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility used by {@link AoeTierController} for spawning a boss and its minions
+ * into an instance. This implementation focuses on simplicity and assumes the
+ * caller manages lifecycle and timers.
+ */
+public class AoeBossSpawner {
+
+    /**
+     * Spawns the boss and minions defined by {@code def} centred on
+     * {@code centre}. Returns the spawned NPCs for tracking.
+     */
+    public static List<NPC> spawn(Player owner, AoeBossTierDef def, Position centre) {
+        List<NPC> spawned = new ArrayList<>();
+        if (def == null || centre == null) {
+            return spawned;
+        }
+        // Spawn boss in centre
+        NPC boss = NPCSpawning.spawnNpc(owner, def.boss.npcId, centre.getX(), centre.getY(), centre.getHeight(), 1, 0, false, false, null);
+        if (boss != null) {
+            spawned.add(boss);
+        }
+        // Offsets for up to three minions around the boss
+        int[][] offsets = new int[][]{{1,0}, {-1,0}, {0,1}, {0,-1}};
+        int spacing = def.getAoeGrid() != null ? def.getAoeGrid().spacing : 1;
+        if (def.minions != null) {
+            for (int i = 0; i < def.minions.size() && i < offsets.length; i++) {
+                AoeBossTierDef.Npc m = def.minions.get(i);
+                int x = centre.getX() + offsets[i][0] * spacing;
+                int y = centre.getY() + offsets[i][1] * spacing;
+                for (int count = 0; count < Math.max(1, m.count); count++) {
+                    NPC npc = NPCSpawning.spawnNpc(owner, m.npcId, x, y, centre.getHeight(), 1, 0, false, false, null);
+                    if (npc != null) {
+                        spawned.add(npc);
+                    }
+                }
+            }
+        }
+        return spawned;
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeBossTierDef.java
+++ b/src/io/xeros/content/instances/aoe/AoeBossTierDef.java
@@ -1,0 +1,87 @@
+package io.xeros.content.instances.aoe;
+
+import java.util.List;
+
+/**
+ * Data driven definition for an AOE boss tier. Instances of this class are
+ * loaded from {@code data/aoe/aoe_boss_tiers.json} via {@link AoeBossTierLoader}.
+ */
+public class AoeBossTierDef {
+
+    public static class Grid {
+        public int rows;
+        public int cols;
+        public int spacing;
+    }
+
+    public static class Npc {
+        public String name;
+        public int npcId;
+        public int count = 1;
+    }
+
+    public static class Rewards {
+        public double xpMultOnTask = 1.0;
+        public double xpMultOffTask = 1.0;
+        public double dropMult = 1.0;
+        public int fortuneXp = 0;
+    }
+
+    public int tier;
+    public String zoneName;
+    public int unlockKills;
+    public Grid aoeGrid;
+    public int aggroRange;
+    public int respawnSeconds;
+    public Npc boss;
+    public List<Npc> minions;
+    public Rewards rewards;
+
+    // Set by loader when a tier cannot be used.
+    public boolean disabled = false;
+    public String disabledReason;
+
+    public int getTier() {
+        return tier;
+    }
+
+    public String getZoneName() {
+        return zoneName;
+    }
+
+    public int getUnlockKills() {
+        return unlockKills;
+    }
+
+    public Grid getAoeGrid() {
+        return aoeGrid;
+    }
+
+    public int getAggroRange() {
+        return aggroRange;
+    }
+
+    public int getRespawnSeconds() {
+        return respawnSeconds;
+    }
+
+    public Npc getBoss() {
+        return boss;
+    }
+
+    public List<Npc> getMinions() {
+        return minions;
+    }
+
+    public Rewards getRewards() {
+        return rewards;
+    }
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public String getDisabledReason() {
+        return disabledReason;
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeBossTierLoader.java
+++ b/src/io/xeros/content/instances/aoe/AoeBossTierLoader.java
@@ -1,0 +1,129 @@
+package io.xeros.content.instances.aoe;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.xeros.model.definitions.NpcDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Loads {@link AoeBossTierDef} definitions from disk and populates
+ * {@link AoeTierRepo}. The loader never returns null and provides
+ * diagnostics when data is missing.
+ */
+public class AoeBossTierLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(AoeBossTierLoader.class);
+    private static final Path FILE = Paths.get("data/aoe/aoe_boss_tiers.json");
+    private static final Gson GSON = new Gson();
+
+    /** Returns the default tier definition file path. */
+    public static Path defaultFile() {
+        return FILE;
+    }
+
+    /** Load tiers from a file. Never returns null. */
+    public static List<AoeBossTierDef> load(File file) {
+        try {
+            if (file == null || !file.exists()) {
+                logger.warn("[AOE] Tier file missing: {}", file != null ? file.getAbsolutePath() : "null");
+                return Collections.emptyList();
+            }
+            String json = Files.readString(file.toPath());
+            List<AoeBossTierDef> tiers = GSON.fromJson(json, new TypeToken<List<AoeBossTierDef>>(){}.getType());
+            if (tiers == null) {
+                return Collections.emptyList();
+            }
+            tiers.forEach(AoeBossTierLoader::resolveNpcIds);
+            return tiers;
+        } catch (IOException e) {
+            logger.error("[AOE] Error loading tiers from {}", file.getAbsolutePath(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /** Load tiers from disk and set repository, logging warnings when empty. */
+    public static void loadAllOrWarn() {
+        loadAllOrWarn("startup");
+    }
+
+    public static void loadAllOrWarn(String sourceTag) {
+        File file = FILE.toFile();
+        if (!file.exists()) {
+            logger.warn("[AOE] Tier file not found at {}. Creating placeholder.", file.getAbsolutePath());
+            createPlaceholder(file);
+        }
+        List<AoeBossTierDef> tiers = load(file);
+        if (tiers.isEmpty()) {
+            logger.warn("[AOE] No tiers found. Checked: {}", file.getAbsolutePath());
+        }
+        AoeTierRepo.set(tiers, sourceTag);
+    }
+
+    private static void resolveNpcIds(AoeBossTierDef def) {
+        if (def == null) {
+            return;
+        }
+        resolve(def.boss, def);
+        if (def.minions != null) {
+            def.minions.forEach(n -> resolve(n, def));
+        }
+    }
+
+    private static void resolve(AoeBossTierDef.Npc npc, AoeBossTierDef tier) {
+        if (npc == null) {
+            return;
+        }
+        if (npc.npcId <= 0) {
+            int id = resolveNpcIdByName(npc.name);
+            if (id > 0) {
+                npc.npcId = id;
+            } else {
+                tier.disabled = true;
+                tier.disabledReason = "npcId unresolved: " + npc.name;
+            }
+        }
+    }
+
+    private static int resolveNpcIdByName(String name) {
+        if (name == null) return -1;
+        for (var entry : NpcDef.getDefinitions().entrySet()) {
+            if (name.equalsIgnoreCase(entry.getValue().getName())) {
+                return entry.getKey();
+            }
+        }
+        return -1;
+    }
+
+    private static void createPlaceholder(File file) {
+        file.getParentFile().mkdirs();
+        AoeBossTierDef placeholder = new AoeBossTierDef();
+        placeholder.tier = 1;
+        placeholder.zoneName = "Unicow Pasture";
+        placeholder.unlockKills = 10;
+        AoeBossTierDef.Npc boss = new AoeBossTierDef.Npc();
+        boss.name = "Unicow";
+        boss.npcId = resolveNpcIdByName("Unicow");
+        placeholder.boss = boss;
+        placeholder.minions = Collections.emptyList();
+        placeholder.aggroRange = 10;
+        placeholder.respawnSeconds = 25;
+        placeholder.rewards = new AoeBossTierDef.Rewards();
+        List<AoeBossTierDef> list = List.of(placeholder);
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(GSON.toJson(list));
+        } catch (IOException e) {
+            logger.error("[AOE] Failed to write placeholder tier file", e);
+        }
+    }
+}
+

--- a/src/io/xeros/content/instances/aoe/AoeDropInterceptor.java
+++ b/src/io/xeros/content/instances/aoe/AoeDropInterceptor.java
@@ -1,0 +1,36 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.items.GameItem;
+
+import java.util.Optional;
+
+/**
+ * Helper to bank drops while inside AOE tier instances.
+ */
+public class AoeDropInterceptor {
+
+    private static final String ATTR_BANK_OVERRIDE = "aoe_reward_bank";
+
+    public static boolean awardInsideAoe(Player player, GameItem item) {
+        if (player == null || item == null) return false;
+        int tier = AoeTierController.getActiveTier(player);
+        if (tier <= 0) return false;
+        Optional<AoeTierRewardsDef> opt = AoeTierRewardsLoader.forTier(tier);
+        if (opt.isEmpty()) return false;
+        AoeTierRewardsDef def = opt.get();
+        boolean bank = player.getAttributes().getBoolean(ATTR_BANK_OVERRIDE, def.isBankAllDrops());
+        if (!bank) return false;
+        if (def.getBlacklist() != null && def.getBlacklist().contains(item.getId())) return false;
+        if (def.getWhitelist() != null && !def.getWhitelist().isEmpty() && !def.getWhitelist().contains(item.getId()))
+            return false;
+        AoeRewardTracker tracker = AoeTierController.getTracker(player);
+        if (tracker != null) tracker.add(item);
+        player.getItems().addItemToBankOrDrop(item.getId(), item.getAmount());
+        return true;
+    }
+
+    public static void setBankOverride(Player player, boolean enable) {
+        player.getAttributes().setBoolean(ATTR_BANK_OVERRIDE, enable);
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeRewardTracker.java
+++ b/src/io/xeros/content/instances/aoe/AoeRewardTracker.java
@@ -1,0 +1,36 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.items.GameItem;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tracks items gained during an AOE tier run.
+ */
+public class AoeRewardTracker {
+
+    private final Map<Integer, Long> items = new LinkedHashMap<>();
+
+    public void add(GameItem item) {
+        items.merge(item.getId(), (long) item.getAmount(), Long::sum);
+    }
+
+    public void addAll(List<GameItem> list) {
+        if (list != null) {
+            list.forEach(this::add);
+        }
+    }
+
+    public List<GameItem> snapshot() {
+        List<GameItem> list = new ArrayList<>();
+        items.forEach((id, amt) -> list.add(new GameItem(id, amt.intValue())));
+        return list;
+    }
+
+    public void clear() {
+        items.clear();
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTierController.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierController.java
@@ -1,0 +1,105 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Position;
+import io.xeros.model.items.GameItem;
+import io.xeros.util.Misc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal controller for starting tiers and tracking player progress. It stores
+ * unlock and killcount data on the {@link Player}'s attribute map to avoid
+ * invasive save changes.
+ */
+public class AoeTierController {
+
+    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AoeTierController.class);
+
+    private static final String ATTR_UNLOCKED = "aoe_unlocked_tier";
+    private static final String ATTR_ACTIVE = "aoe_active_tier";
+    private static final String ATTR_TRACKER = "aoe_reward_tracker";
+    private static String kcKey(int tier) { return "aoe_kc_" + tier; }
+
+    public static int getUnlockedTier(Player player) {
+        return player.getAttributes().getInt(ATTR_UNLOCKED, 1);
+    }
+
+    public static int getKillCount(Player player, int tier) {
+        return player.getAttributes().getInt(kcKey(tier), 0);
+    }
+
+    public static void setUnlockedTier(Player player, int tier) {
+        player.getAttributes().setInt(ATTR_UNLOCKED, tier);
+    }
+
+    public static void incrementKill(Player player, int tier) {
+        int kc = getKillCount(player, tier) + 1;
+        player.getAttributes().setInt(kcKey(tier), kc);
+        AoeBossTierDef def = AoeTierRepo.byTier(tier);
+        if (def != null && kc >= def.unlockKills && tier >= getUnlockedTier(player)) {
+            setUnlockedTier(player, tier + 1);
+            player.sendMessage("\uD83D\uDD13 You have unlocked AOE tier " + (tier + 1) + ".");
+        }
+    }
+
+    /** Starts the given tier at the player's current location. */
+    public static List<NPC> startTier(Player player, int tier) {
+        endTier(player, false);
+        AoeBossTierDef def = AoeTierRepo.byTier(tier);
+        if (def == null) {
+            player.sendMessage("Unknown tier: " + tier);
+            return List.of();
+        }
+        if (def.disabled) {
+            player.sendMessage("Tier disabled: " + def.getDisabledReason());
+            logger.info("[AOE] Start refused: disabled: {}", def.getDisabledReason());
+            return List.of();
+        }
+        if (tier > getUnlockedTier(player)) {
+            player.sendMessage("You have not unlocked this tier yet.");
+            return List.of();
+        }
+        player.getAttributes().setInt(ATTR_ACTIVE, tier);
+        player.getAttributes().set(ATTR_TRACKER, new AoeRewardTracker());
+        Position centre = new Position(player.absX, player.absY, player.heightLevel);
+        return AoeBossSpawner.spawn(player, def, centre);
+    }
+
+    public static int getActiveTier(Player player) {
+        return player.getAttributes().getInt(ATTR_ACTIVE, 0);
+    }
+
+    public static AoeRewardTracker getTracker(Player player) {
+        Object obj = player.getAttributes().get(ATTR_TRACKER);
+        return obj instanceof AoeRewardTracker ? (AoeRewardTracker) obj : null;
+    }
+
+    public static void endTier(Player player, boolean showReport) {
+        int tier = getActiveTier(player);
+        if (tier <= 0) return;
+        AoeRewardTracker tracker = getTracker(player);
+        List<GameItem> loot = tracker != null ? tracker.snapshot() : new ArrayList<>();
+        List<GameItem> finalLoot = new ArrayList<>(loot);
+        AoeTierRewardsLoader.forTier(tier).ifPresent(def -> {
+            for (int i = 0; i < def.getEndOfRunRolls(); i++) {
+                if (def.getBonusRewards() != null) {
+                    for (AoeTierRewardsDef.BonusReward br : def.getBonusRewards()) {
+                        int amt = Misc.random(br.min, br.max);
+                        GameItem gi = new GameItem(br.itemId, amt);
+                        finalLoot.add(gi);
+                        player.getItems().addItemToBankOrDrop(gi.getId(), gi.getAmount());
+                    }
+                }
+            }
+            if (showReport && !finalLoot.isEmpty()) {
+                AoeTreasureTrailsAdapter.openLootViewer(player, def.getReportTitle(), finalLoot);
+            }
+        });
+        if (tracker != null) tracker.clear();
+        player.getAttributes().remove(ATTR_TRACKER);
+        player.getAttributes().removeInt(ATTR_ACTIVE);
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTierDebug.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierDebug.java
@@ -1,0 +1,163 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.Server;
+import io.xeros.content.commands.Command;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.entity.player.Right;
+import io.xeros.model.items.GameItem;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import java.util.Optional;
+
+/**
+ * Implements the ::aoe command set used for testing the
+ * data driven AOE boss tiers and reward system.
+ */
+public class AoeTierDebug extends Command {
+
+    @Override
+    public void execute(Player player, String commandName, String input) {
+        String[] parts = input.split(" ");
+        if (parts.length == 0) {
+            player.sendMessage("Usage: ::aoe <tier|rewards> ...");
+            return;
+        }
+        String category = parts[0].toLowerCase();
+        if ("tier".equals(category)) {
+            if (parts.length < 2) {
+                player.sendMessage("Usage: ::aoe tier <open|status|start|set|simulate|reload>");
+                return;
+            }
+            String sub = parts[1].toLowerCase();
+            switch (sub) {
+                case "open":
+                    player.start(new io.xeros.content.dialogue.impl.BossInstanceDialogue(player));
+                    break;
+                case "status":
+                    int size = AoeTierRepo.size();
+                    String sample = AoeTierRepo.get().stream().limit(3)
+                            .map(def -> def.zoneName)
+                            .collect(Collectors.joining(", "));
+                    String path = AoeBossTierLoader.defaultFile().toFile().getAbsolutePath();
+                    player.sendMessage("Repo size=" + size + " sample=" + sample + " file=" + path);
+                    break;
+                case "start":
+                    if (parts.length >= 3) {
+                        int t = Integer.parseInt(parts[2]);
+                        AoeTierController.startTier(player, t);
+                    } else {
+                        player.sendMessage("Usage: ::aoe tier start <tier>");
+                    }
+                    break;
+                case "set":
+                    if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                        player.sendMessage("Admin only command.");
+                        return;
+                    }
+                    if (parts.length >= 3) {
+                        int t = Integer.parseInt(parts[2]);
+                        AoeTierController.setUnlockedTier(player, t);
+                        player.sendMessage("Set unlocked AOE tier to " + t);
+                    } else {
+                        player.sendMessage("Usage: ::aoe tier set <tier>");
+                    }
+                    break;
+                case "simulate":
+                    if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                        player.sendMessage("Admin only command.");
+                        return;
+                    }
+                    if (parts.length >= 4) {
+                        int t = Integer.parseInt(parts[2]);
+                        int kills = Integer.parseInt(parts[3]);
+                        for (int i = 0; i < kills; i++) {
+                            AoeTierController.incrementKill(player, t);
+                        }
+                        player.sendMessage("Simulated " + kills + " kills for tier " + t);
+                    } else {
+                        player.sendMessage("Usage: ::aoe tier simulate <tier> <kills>");
+                    }
+                    break;
+                case "reload":
+                    if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                        player.sendMessage("Admin only command.");
+                        return;
+                    }
+                    Arrays.stream(Server.playerHandler.players)
+                            .filter(p -> p != null && AoeTierController.getActiveTier(p) > 0)
+                            .forEach(p -> AoeTierController.endTier(p, false));
+                    AoeBossTierLoader.loadAllOrWarn("reload");
+                    player.sendMessage("AOE tier definitions reloaded. Count=" + AoeTierRepo.size());
+                    break;
+                default:
+                    player.sendMessage("Unknown subcommand: " + sub);
+            }
+        } else if ("rewards".equals(category)) {
+            if (parts.length < 2) {
+                player.sendMessage("Usage: ::aoe rewards <show|clear|bank|reload|simulate>");
+                return;
+            }
+            String sub = parts[1].toLowerCase();
+            switch (sub) {
+                case "show":
+                    AoeRewardTracker tracker = AoeTierController.getTracker(player);
+                    if (tracker != null) {
+                        AoeTreasureTrailsAdapter.openLootViewer(player, "AOE Tier Rewards", tracker.snapshot());
+                    } else {
+                        player.sendMessage("No active rewards.");
+                    }
+                    break;
+                case "clear":
+                    AoeRewardTracker t = AoeTierController.getTracker(player);
+                    if (t != null) t.clear();
+                    player.sendMessage("AOE reward tracker cleared.");
+                    break;
+                case "bank":
+                    if (parts.length >= 3) {
+                        boolean on = parts[2].equalsIgnoreCase("on");
+                        AoeDropInterceptor.setBankOverride(player, on);
+                        player.sendMessage("AOE auto bank " + (on ? "enabled" : "disabled"));
+                    } else {
+                        player.sendMessage("Usage: ::aoe rewards bank on|off");
+                    }
+                    break;
+                case "reload":
+                    if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                        player.sendMessage("Admin only command.");
+                        return;
+                    }
+                    AoeTierRewardsLoader.reload();
+                    player.sendMessage("AOE tier rewards reloaded.");
+                    break;
+                case "simulate":
+                    if (!Right.ADMINISTRATOR.isOrInherits(player)) {
+                        player.sendMessage("Admin only command.");
+                        return;
+                    }
+                    if (parts.length >= 4) {
+                        int id = Integer.parseInt(parts[2]);
+                        int amt = Integer.parseInt(parts[3]);
+                        AoeDropInterceptor.awardInsideAoe(player, new GameItem(id, amt));
+                    } else {
+                        player.sendMessage("Usage: ::aoe rewards simulate <itemId> <amount>");
+                    }
+                    break;
+                default:
+                    player.sendMessage("Unknown subcommand: " + sub);
+            }
+        } else {
+            player.sendMessage("Usage: ::aoe <tier|rewards> ...");
+        }
+    }
+
+    @Override
+    public boolean hasPrivilege(Player player) {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("AOE tier utilities");
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTierEvents.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierEvents.java
@@ -1,0 +1,42 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.Server;
+import io.xeros.model.entity.npc.NPC;
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.items.GameItem;
+
+import java.util.List;
+
+/**
+ * Static hooks that tie the tier system into NPC death events. The actual game
+ * engine should call {@link #onNpcDeath(Player, NPC)} whenever an NPC dies so
+ * that kill counts can be tracked.
+ */
+public class AoeTierEvents {
+
+    public static void onNpcDeath(Player player, NPC npc) {
+        if (player == null || npc == null) {
+            return;
+        }
+        int tier = AoeTierController.getActiveTier(player);
+        if (tier > 0) {
+            List<GameItem> drops = Server.getDropManager().getDropSample(player, npc.npcId);
+            if (drops != null) {
+                for (GameItem gi : drops) {
+                    if (!AoeDropInterceptor.awardInsideAoe(player, gi)) {
+                        Server.itemHandler.createGroundItem(player, gi.getId(), npc.getX(), npc.getY(), player.heightLevel, gi.getAmount(), player.getIndex(), false);
+                    }
+                }
+            }
+            AoeBossTierDef def = AoeTierRepo.byTier(tier);
+            if (def != null && def.boss != null && def.boss.npcId == npc.npcId) {
+                AoeTierController.incrementKill(player, tier);
+                AoeTierRewardsLoader.forTier(tier).ifPresent(r -> {
+                    if (r.getFortuneXpPerKill() > 0) {
+                        player.addDemonHunterXP(r.getFortuneXpPerKill());
+                    }
+                });
+            }
+        }
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTierRepo.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierRepo.java
@@ -1,0 +1,44 @@
+package io.xeros.content.instances.aoe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * In-memory repository for AOE boss tier definitions. Acts as the single
+ * source of truth that other components query.
+ */
+public class AoeTierRepo {
+
+    private static final Logger logger = LoggerFactory.getLogger(AoeTierRepo.class);
+    private static final AtomicReference<List<AoeBossTierDef>> TIERS =
+            new AtomicReference<>(Collections.emptyList());
+
+    public static List<AoeBossTierDef> get() {
+        return Collections.unmodifiableList(TIERS.get());
+    }
+
+    public static int size() {
+        return TIERS.get().size();
+    }
+
+    public static void set(List<AoeBossTierDef> tiers, String sourceTag) {
+        List<AoeBossTierDef> copy = tiers == null ? Collections.emptyList() : List.copyOf(tiers);
+        TIERS.set(copy);
+        String first = copy.isEmpty() ? "none" : ("T" + copy.get(0).tier + " " + copy.get(0).zoneName);
+        logger.info("[AOE] Tiers loaded: {} from {} (first: {})", copy.size(), sourceTag, first);
+    }
+
+    public static AoeBossTierDef byTier(int tier) {
+        for (AoeBossTierDef def : TIERS.get()) {
+            if (def.tier == tier) {
+                return def;
+            }
+        }
+        return null;
+    }
+}
+

--- a/src/io/xeros/content/instances/aoe/AoeTierRewardsDef.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierRewardsDef.java
@@ -1,0 +1,35 @@
+package io.xeros.content.instances.aoe;
+
+import java.util.List;
+
+/**
+ * Definition of extra rewards and behaviour per AOE tier instance.
+ */
+public class AoeTierRewardsDef {
+
+    public static class BonusReward {
+        public int itemId;
+        public int min;
+        public int max;
+    }
+
+    public int tier;
+    public String name;
+    public int endOfRunRolls;
+    public List<BonusReward> bonusRewards;
+    public boolean bankAllDrops = true;
+    public List<Integer> blacklist;
+    public List<Integer> whitelist;
+    public int fortuneXpPerKill;
+    public String reportTitle;
+
+    public int getTier() { return tier; }
+    public String getName() { return name; }
+    public int getEndOfRunRolls() { return endOfRunRolls; }
+    public List<BonusReward> getBonusRewards() { return bonusRewards; }
+    public boolean isBankAllDrops() { return bankAllDrops; }
+    public List<Integer> getBlacklist() { return blacklist; }
+    public List<Integer> getWhitelist() { return whitelist; }
+    public int getFortuneXpPerKill() { return fortuneXpPerKill; }
+    public String getReportTitle() { return reportTitle; }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTierRewardsLoader.java
+++ b/src/io/xeros/content/instances/aoe/AoeTierRewardsLoader.java
@@ -1,0 +1,51 @@
+package io.xeros.content.instances.aoe;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Loads tier reward definitions from {@code data/aoe/aoe_tier_rewards.json}.
+ */
+public class AoeTierRewardsLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(AoeTierRewardsLoader.class);
+    private static final Path FILE = Paths.get("data/aoe/aoe_tier_rewards.json");
+    private static final Gson GSON = new Gson();
+
+    private static List<AoeTierRewardsDef> defs = Collections.emptyList();
+
+    static { load(); }
+
+    public static void load() {
+        try {
+            if (!Files.exists(FILE)) {
+                logger.warn("AOE tier rewards file not found: {}", FILE.toAbsolutePath());
+                defs = Collections.emptyList();
+                return;
+            }
+            String json = Files.readString(FILE);
+            defs = GSON.fromJson(json, new TypeToken<List<AoeTierRewardsDef>>(){}.getType());
+            if (defs == null) defs = Collections.emptyList();
+            logger.info("Loaded {} AOE tier reward defs.", defs.size());
+        } catch (IOException e) {
+            logger.error("Error loading AOE tier rewards", e);
+            defs = Collections.emptyList();
+        }
+    }
+
+    public static void reload() { load(); }
+
+    public static Optional<AoeTierRewardsDef> forTier(int tier) {
+        return defs.stream().filter(d -> d.tier == tier).findFirst();
+    }
+}

--- a/src/io/xeros/content/instances/aoe/AoeTreasureTrailsAdapter.java
+++ b/src/io/xeros/content/instances/aoe/AoeTreasureTrailsAdapter.java
@@ -1,0 +1,18 @@
+package io.xeros.content.instances.aoe;
+
+import io.xeros.model.entity.player.Player;
+import io.xeros.model.items.GameItem;
+
+import java.util.List;
+
+/**
+ * Adapter for displaying loot using the Treasure Trails reward interface.
+ */
+public class AoeTreasureTrailsAdapter {
+
+    public static void openLootViewer(Player player, String title, List<GameItem> items) {
+        if (player == null) return;
+        player.getPA().sendString(title, 6961);
+        player.getTrails().displayRewards(items);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize AOE boss tiers in a runtime repo with explicit logging
- harden tier loader with placeholder creation, disabled-tier tagging, and startup wiring
- paginate AOE tier dialogue and block disabled tiers; expand ::aoe tier debug commands

## Testing
- `gradle test` *(fails: NoSuchFieldError: JCTree$JCImport.qualid)*

------
https://chatgpt.com/codex/tasks/task_e_68b62385af0c8320a2093f76bc5000f4